### PR TITLE
Implement Clerk authentication middleware

### DIFF
--- a/apps/server/src/app.test.ts
+++ b/apps/server/src/app.test.ts
@@ -1,5 +1,17 @@
+import { jest } from '@jest/globals';
 import request from 'supertest';
-import { app } from './index.js';
+import type { Request, Response, NextFunction } from 'express';
+
+// Mock the auth middleware before importing the app
+jest.unstable_mockModule('@/middlewares/auth.js', () => ({
+  clerkMiddleware: () => (_req: Request, _res: Response, next: NextFunction) =>
+    next(),
+  requireAuth: (_req: Request, _res: Response, next: NextFunction) => next(),
+  getAuth: () => ({ userId: 'test-user' }),
+}));
+
+// Dynamic import after mock is set up
+const { app } = await import('./index.js');
 
 describe('App - Unit Tests', () => {
   describe('GET /health', () => {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,5 +1,6 @@
 import express, { type Express } from 'express';
 import cors from 'cors';
+import { clerkMiddleware } from '@/middlewares/auth.js';
 
 // Import routes
 import decksRouter from '@/routes/decks.js';
@@ -13,6 +14,10 @@ const PORT = process.env.PORT || 3000;
 // Middleware
 app.use(cors());
 app.use(express.json());
+
+// Clerk authentication middleware - attaches auth state to all requests
+// Individual routes can use requireAuth or getAuth to check authentication
+app.use(clerkMiddleware());
 
 // Health check
 app.get('/health', (_req, res) => {

--- a/apps/server/src/middlewares/auth.test.ts
+++ b/apps/server/src/middlewares/auth.test.ts
@@ -1,0 +1,82 @@
+import { jest } from '@jest/globals';
+import request from 'supertest';
+import express, {
+  type Express,
+  type Request,
+  type Response,
+  type NextFunction,
+} from 'express';
+
+// Mock @clerk/express before importing our auth module
+const mockGetAuth = jest.fn();
+jest.unstable_mockModule('@clerk/express', () => ({
+  clerkMiddleware: () => (_req: Request, _res: Response, next: NextFunction) =>
+    next(),
+  getAuth: mockGetAuth,
+}));
+
+// Dynamic import after mock is set up
+const { requireAuth } = await import('@/middlewares/auth.js');
+
+// Helper to create test app
+function createTestApp(): Express {
+  const app = express();
+  app.use(express.json());
+
+  // Protected route using requireAuth
+  app.get('/protected', requireAuth, (req, res) => {
+    res.json({ message: 'success', userId: mockGetAuth(req).userId });
+  });
+
+  return app;
+}
+
+describe('Auth Middleware - Unit Tests', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('requireAuth', () => {
+    it('should return 401 when user is not authenticated', async () => {
+      mockGetAuth.mockReturnValue({ userId: null });
+
+      const app = createTestApp();
+      const response = await request(app).get('/protected');
+
+      expect(response.status).toBe(401);
+      expect(response.body.error.code).toBe('UNAUTHORIZED');
+      expect(response.body.error.message).toBe('Authentication required');
+    });
+
+    it('should return 401 when userId is undefined', async () => {
+      mockGetAuth.mockReturnValue({ userId: undefined });
+
+      const app = createTestApp();
+      const response = await request(app).get('/protected');
+
+      expect(response.status).toBe(401);
+      expect(response.body.error.code).toBe('UNAUTHORIZED');
+    });
+
+    it('should allow request when user is authenticated', async () => {
+      mockGetAuth.mockReturnValue({ userId: 'user_123' });
+
+      const app = createTestApp();
+      const response = await request(app).get('/protected');
+
+      expect(response.status).toBe(200);
+      expect(response.body.message).toBe('success');
+      expect(response.body.userId).toBe('user_123');
+    });
+
+    it('should call next() for authenticated users', async () => {
+      mockGetAuth.mockReturnValue({ userId: 'user_456' });
+
+      const app = createTestApp();
+      const response = await request(app).get('/protected');
+
+      expect(response.status).toBe(200);
+      expect(mockGetAuth).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/server/src/middlewares/auth.ts
+++ b/apps/server/src/middlewares/auth.ts
@@ -1,0 +1,41 @@
+import { clerkMiddleware, getAuth, type AuthObject } from '@clerk/express';
+import type { Request, Response, NextFunction, RequestHandler } from 'express';
+
+// Re-export clerkMiddleware for use in index.ts
+export { clerkMiddleware, getAuth };
+
+// Re-export AuthObject type for use in route handlers
+export type { AuthObject };
+
+/**
+ * Middleware that requires authentication.
+ * Returns 401 JSON response if user is not authenticated.
+ *
+ * Unlike Clerk's built-in requireAuth() which redirects to a sign-in page,
+ * this middleware is designed for API routes and returns JSON errors.
+ *
+ * Usage:
+ *   router.get('/protected', requireAuth, (req, res) => {
+ *     const { userId } = getAuth(req);
+ *     // ...
+ *   });
+ */
+export const requireAuth: RequestHandler = (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  const auth = getAuth(req);
+
+  if (!auth.userId) {
+    res.status(401).json({
+      error: {
+        code: 'UNAUTHORIZED',
+        message: 'Authentication required',
+      },
+    });
+    return;
+  }
+
+  next();
+};

--- a/apps/server/src/routes/decks.test.ts
+++ b/apps/server/src/routes/decks.test.ts
@@ -1,6 +1,11 @@
 import { jest } from '@jest/globals';
 import request from 'supertest';
-import express from 'express';
+import express, {
+  type Express,
+  type Request,
+  type Response,
+  type NextFunction,
+} from 'express';
 import { mockDeep, mockReset } from 'jest-mock-extended';
 import { PrismaClient, Prisma } from '@/generated/prisma/index.js';
 import DeckGetPayload = Prisma.DeckGetPayload;
@@ -8,37 +13,77 @@ import DeckGetPayload = Prisma.DeckGetPayload;
 // Create a mock prisma client
 const prismaMock = mockDeep<PrismaClient>();
 
+// Mock getAuth to return a specific userId
+const mockGetAuth = jest.fn();
+
 // Mock the prisma module before importing the router
 jest.unstable_mockModule('@/lib/prisma.js', () => ({
   prisma: prismaMock,
 }));
 
+// Mock the auth middleware
+jest.unstable_mockModule('@/middlewares/auth.js', () => ({
+  requireAuth: (_req: Request, _res: Response, next: NextFunction) => next(),
+  getAuth: mockGetAuth,
+}));
+
 // Dynamic import after mock is set up
 const { default: decksRouter } = await import('@/routes/decks.js');
 
-// Create a test app with the router
-const app = express();
-app.use(express.json());
-app.use('/api/decks', decksRouter);
+// Helper to create test app
+function createTestApp(): Express {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/decks', decksRouter);
 
-// Add 404 handler
-app.use((_req, res) => {
-  res.status(404).json({ error: 'Route not found' });
-});
+  // Add 404 handler
+  app.use((_req, res) => {
+    res.status(404).json({ error: 'Route not found' });
+  });
+
+  return app;
+}
+
+const app = createTestApp();
 
 describe('Decks Routes - Unit Tests', () => {
   beforeEach(() => {
     mockReset(prismaMock);
+    mockGetAuth.mockReset();
+    // Default: authenticated user
+    mockGetAuth.mockReturnValue({ userId: 'clerk-user-123' });
   });
 
   describe('GET /api/decks', () => {
+    it('should return 401 when user not found in database', async () => {
+      prismaMock.user.findUnique.mockResolvedValue(null);
+
+      const response = await request(app).get('/api/decks');
+
+      expect(response.status).toBe(401);
+      expect(response.body.error.code).toBe('UNAUTHORIZED');
+      expect(response.body.error.message).toBe('User not found');
+    });
+
     it('should return decks for the authenticated user', async () => {
+      const now = new Date();
+
+      // Mock user lookup
+      prismaMock.user.findUnique.mockResolvedValue({
+        id: 'user-internal-id',
+        clerkId: 'clerk-user-123',
+        pushToken: null,
+        notificationsEnabled: true,
+        createdAt: now,
+        updatedAt: now,
+      });
+
       const mockDecks = [
         {
           id: 'deck-1',
           title: 'JavaScript Basics',
           description: 'Learn JS fundamentals',
-          userId: 'cmhvc9rh100002gq791i0fsqd',
+          userId: 'user-internal-id',
           parentDeckId: null,
           createdAt: new Date('2024-01-01'),
           updatedAt: new Date('2024-01-01'),
@@ -49,8 +94,6 @@ describe('Decks Routes - Unit Tests', () => {
         include: { subDecks: true; _count: { select: { cards: true } } };
       }>[];
 
-      // Cast needed because mockResolvedValue expects Deck[], but findMany with
-      // include returns DeckWithRelations[] at runtime
       prismaMock.deck.findMany.mockResolvedValue(mockDecks);
 
       const response = await request(app).get('/api/decks');
@@ -58,10 +101,24 @@ describe('Decks Routes - Unit Tests', () => {
       expect(response.status).toBe(200);
       expect(response.body).toHaveProperty('decks');
       expect(response.body).toHaveProperty('total');
-      expect(prismaMock.deck.findMany).toHaveBeenCalled();
+      expect(prismaMock.deck.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { userId: 'user-internal-id' },
+        }),
+      );
     });
 
     it('should return empty array when user has no decks', async () => {
+      const now = new Date();
+
+      prismaMock.user.findUnique.mockResolvedValue({
+        id: 'user-internal-id',
+        clerkId: 'clerk-user-123',
+        pushToken: null,
+        notificationsEnabled: true,
+        createdAt: now,
+        updatedAt: now,
+      });
       prismaMock.deck.findMany.mockResolvedValue([]);
 
       const response = await request(app).get('/api/decks');
@@ -72,6 +129,16 @@ describe('Decks Routes - Unit Tests', () => {
     });
 
     it('should handle database errors gracefully', async () => {
+      const now = new Date();
+
+      prismaMock.user.findUnique.mockResolvedValue({
+        id: 'user-internal-id',
+        clerkId: 'clerk-user-123',
+        pushToken: null,
+        notificationsEnabled: true,
+        createdAt: now,
+        updatedAt: now,
+      });
       prismaMock.deck.findMany.mockRejectedValue(new Error('Database error'));
 
       const response = await request(app).get('/api/decks');


### PR DESCRIPTION
Closes #11

## Summary
- Implements Clerk authentication middleware for Express routes
- Provides `requireAuth` middleware that returns 401 JSON for unauthenticated API requests
- Updates `GET /api/decks` to use real authentication instead of hardcoded userId

## Changes
- `apps/server/src/middlewares/auth.ts`: New auth middleware module with `clerkMiddleware`, `requireAuth`, and `getAuth` exports
- `apps/server/src/middlewares/auth.test.ts`: Unit tests for requireAuth middleware
- `apps/server/src/index.ts`: Apply clerkMiddleware globally
- `apps/server/src/routes/decks.ts`: Use requireAuth and getAuth, look up internal user by Clerk ID
- `apps/server/src/routes/decks.test.ts`: Updated to mock auth middleware
- `apps/server/src/app.test.ts`: Updated to mock auth middleware

## Test Coverage
- requireAuth returns 401 when userId is null
- requireAuth returns 401 when userId is undefined
- requireAuth allows authenticated requests
- requireAuth calls next() for authenticated users
- GET /api/decks returns 401 when user not found in database
- GET /api/decks returns decks for authenticated user (using internal userId)