### PR TITLE
Implement query function to find cards due for review

### DIFF
--- a/apps/server/src/services/__tests__/due-cards.test.ts
+++ b/apps/server/src/services/__tests__/due-cards.test.ts
@@ -1,0 +1,310 @@
+import { findDueCards, countDueCards } from '@/services/due-cards';
+import { prisma } from '@/lib/prisma';
+
+// Mock Prisma
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    card: {
+      findMany: jest.fn(),
+      count: jest.fn(),
+    },
+    user: {
+      findMany: jest.fn(),
+    },
+  },
+}));
+
+const mockPrisma = prisma as jest.Mocked<typeof prisma>;
+
+describe('Due Cards Service', () => {
+  const now = new Date('2024-01-15T10:00:00.000Z');
+
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(now);
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('findDueCards', () => {
+    it('should find cards due within the notification window', async () => {
+      const mockCards = [
+        {
+          id: 'card-1',
+          front: 'Question 1',
+          nextReviewDate: new Date('2024-01-15T10:05:00.000Z'),
+          lastNotificationSent: null,
+          snoozedUntil: null,
+          deck: {
+            id: 'deck-1',
+            title: 'Math',
+            userId: 'user-1',
+            parentDeckId: null,
+          },
+        },
+        {
+          id: 'card-2',
+          front: 'Question 2',
+          nextReviewDate: new Date('2024-01-15T09:55:00.000Z'),
+          lastNotificationSent: null,
+          snoozedUntil: null,
+          deck: {
+            id: 'deck-2',
+            title: 'Science',
+            userId: 'user-1',
+            parentDeckId: null,
+          },
+        },
+      ];
+
+      const mockUsers = [
+        {
+          id: 'user-1',
+          clerkId: 'clerk-1',
+          pushToken: 'ExponentPushToken[xxx]',
+          notificationsEnabled: true,
+        },
+      ];
+
+      (mockPrisma.card.findMany as jest.Mock).mockResolvedValue(mockCards);
+      (mockPrisma.user.findMany as jest.Mock).mockResolvedValue(mockUsers);
+
+      const result = await findDueCards();
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toMatchObject({
+        id: 'card-1',
+        deck: { title: 'Math' },
+        user: { pushToken: 'ExponentPushToken[xxx]' },
+      });
+
+      // Verify the query was called with AND conditions including time window
+      expect(mockPrisma.card.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            AND: expect.arrayContaining([
+              expect.objectContaining({
+                nextReviewDate: {
+                  gte: new Date('2024-01-15T09:53:00.000Z'), // now - 7 min
+                  lte: new Date('2024-01-15T10:07:00.000Z'), // now + 7 min
+                },
+              }),
+            ]),
+          }),
+        }),
+      );
+    });
+
+    it('should exclude cards from users without push tokens', async () => {
+      (mockPrisma.card.findMany as jest.Mock).mockResolvedValue([]);
+      (mockPrisma.user.findMany as jest.Mock).mockResolvedValue([]);
+
+      await findDueCards();
+
+      expect(mockPrisma.card.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            AND: expect.arrayContaining([
+              expect.objectContaining({
+                deck: {
+                  user: {
+                    notificationsEnabled: true,
+                    pushToken: { not: null },
+                  },
+                },
+              }),
+            ]),
+          }),
+        }),
+      );
+    });
+
+    it('should exclude snoozed cards', async () => {
+      (mockPrisma.card.findMany as jest.Mock).mockResolvedValue([]);
+      (mockPrisma.user.findMany as jest.Mock).mockResolvedValue([]);
+
+      await findDueCards();
+
+      expect(mockPrisma.card.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            AND: expect.arrayContaining([
+              expect.objectContaining({
+                OR: [{ snoozedUntil: null }, { snoozedUntil: { lte: now } }],
+              }),
+            ]),
+          }),
+        }),
+      );
+    });
+
+    it('should use custom window minutes when provided', async () => {
+      (mockPrisma.card.findMany as jest.Mock).mockResolvedValue([]);
+      (mockPrisma.user.findMany as jest.Mock).mockResolvedValue([]);
+
+      await findDueCards({ windowMinutes: 15 });
+
+      expect(mockPrisma.card.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            AND: expect.arrayContaining([
+              expect.objectContaining({
+                nextReviewDate: {
+                  gte: new Date('2024-01-15T09:45:00.000Z'), // now - 15 min
+                  lte: new Date('2024-01-15T10:15:00.000Z'), // now + 15 min
+                },
+              }),
+            ]),
+          }),
+        }),
+      );
+    });
+
+    it('should filter out cards without matching users', async () => {
+      const mockCards = [
+        {
+          id: 'card-1',
+          front: 'Question 1',
+          nextReviewDate: new Date('2024-01-15T10:05:00.000Z'),
+          lastNotificationSent: null,
+          snoozedUntil: null,
+          deck: {
+            id: 'deck-1',
+            title: 'Math',
+            userId: 'user-1',
+            parentDeckId: null,
+          },
+        },
+      ];
+
+      // Return empty users array - no matching user
+      (mockPrisma.card.findMany as jest.Mock).mockResolvedValue(mockCards);
+      (mockPrisma.user.findMany as jest.Mock).mockResolvedValue([]);
+
+      const result = await findDueCards();
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('should handle multiple users correctly', async () => {
+      const mockCards = [
+        {
+          id: 'card-1',
+          front: 'Q1',
+          nextReviewDate: now,
+          lastNotificationSent: null,
+          snoozedUntil: null,
+          deck: {
+            id: 'deck-1',
+            title: 'Math',
+            userId: 'user-1',
+            parentDeckId: null,
+          },
+        },
+        {
+          id: 'card-2',
+          front: 'Q2',
+          nextReviewDate: now,
+          lastNotificationSent: null,
+          snoozedUntil: null,
+          deck: {
+            id: 'deck-2',
+            title: 'Science',
+            userId: 'user-2',
+            parentDeckId: null,
+          },
+        },
+      ];
+
+      const mockUsers = [
+        {
+          id: 'user-1',
+          clerkId: 'clerk-1',
+          pushToken: 'token-1',
+          notificationsEnabled: true,
+        },
+        {
+          id: 'user-2',
+          clerkId: 'clerk-2',
+          pushToken: 'token-2',
+          notificationsEnabled: true,
+        },
+      ];
+
+      (mockPrisma.card.findMany as jest.Mock).mockResolvedValue(mockCards);
+      (mockPrisma.user.findMany as jest.Mock).mockResolvedValue(mockUsers);
+
+      const result = await findDueCards();
+
+      expect(result).toHaveLength(2);
+      expect(result[0].user.id).toBe('user-1');
+      expect(result[1].user.id).toBe('user-2');
+    });
+  });
+
+  describe('countDueCards', () => {
+    it('should return the count of due cards', async () => {
+      (mockPrisma.card.count as jest.Mock).mockResolvedValue(5);
+
+      const result = await countDueCards();
+
+      expect(result).toBe(5);
+    });
+
+    it('should use the same filters as findDueCards', async () => {
+      (mockPrisma.card.count as jest.Mock).mockResolvedValue(0);
+
+      await countDueCards();
+
+      expect(mockPrisma.card.count).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            AND: expect.arrayContaining([
+              expect.objectContaining({
+                nextReviewDate: {
+                  gte: new Date('2024-01-15T09:53:00.000Z'),
+                  lte: new Date('2024-01-15T10:07:00.000Z'),
+                },
+              }),
+              expect.objectContaining({
+                deck: {
+                  user: {
+                    notificationsEnabled: true,
+                    pushToken: { not: null },
+                  },
+                },
+              }),
+            ]),
+          }),
+        }),
+      );
+    });
+
+    it('should use custom window minutes when provided', async () => {
+      (mockPrisma.card.count as jest.Mock).mockResolvedValue(0);
+
+      await countDueCards({ windowMinutes: 10 });
+
+      expect(mockPrisma.card.count).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            AND: expect.arrayContaining([
+              expect.objectContaining({
+                nextReviewDate: {
+                  gte: new Date('2024-01-15T09:50:00.000Z'),
+                  lte: new Date('2024-01-15T10:10:00.000Z'),
+                },
+              }),
+            ]),
+          }),
+        }),
+      );
+    });
+  });
+});

--- a/apps/server/src/services/due-cards.ts
+++ b/apps/server/src/services/due-cards.ts
@@ -1,0 +1,223 @@
+import { prisma } from '@/lib/prisma';
+import type { Card, Deck, User } from '@/generated/prisma';
+
+/**
+ * Notification window in minutes (±7 minutes from current time).
+ */
+const NOTIFICATION_WINDOW_MINUTES = 7;
+
+/**
+ * Minimum time between notifications for the same card (in minutes).
+ * Prevents re-notifying cards that were recently notified.
+ */
+const MIN_NOTIFICATION_INTERVAL_MINUTES = 30;
+
+/**
+ * Card with related deck and user information for notification processing.
+ */
+export interface DueCardWithRelations {
+  id: string;
+  front: string;
+  nextReviewDate: Date;
+  lastNotificationSent: Date | null;
+  snoozedUntil: Date | null;
+  deck: {
+    id: string;
+    title: string;
+    userId: string;
+    parentDeckId: string | null;
+  };
+  user: {
+    id: string;
+    clerkId: string;
+    pushToken: string | null;
+    notificationsEnabled: boolean;
+  };
+}
+
+/**
+ * Options for the due cards query.
+ */
+export interface FindDueCardsOptions {
+  /**
+   * Custom notification window in minutes (defaults to 7).
+   */
+  windowMinutes?: number;
+
+  /**
+   * Whether to exclude cards that have been notified recently.
+   * Defaults to true.
+   */
+  excludeRecentlyNotified?: boolean;
+}
+
+/**
+ * Finds cards that are due for review within the notification window.
+ *
+ * The query:
+ * 1. Finds cards where nextReviewDate is within ±7 minutes of now
+ * 2. Excludes cards where snoozedUntil > now (user snoozed the card)
+ * 3. Excludes cards that were notified within the last 30 minutes
+ * 4. Only includes cards from users with notifications enabled and a push token
+ * 5. Includes related deck and user information for grouping
+ *
+ * @param options - Query options
+ * @returns Array of due cards with deck and user relations
+ */
+export async function findDueCards(
+  options: FindDueCardsOptions = {},
+): Promise<DueCardWithRelations[]> {
+  const {
+    windowMinutes = NOTIFICATION_WINDOW_MINUTES,
+    excludeRecentlyNotified = true,
+  } = options;
+
+  const now = new Date();
+  const windowStart = new Date(now.getTime() - windowMinutes * 60 * 1000);
+  const windowEnd = new Date(now.getTime() + windowMinutes * 60 * 1000);
+
+  // Calculate the cutoff for "recently notified" cards
+  const recentNotificationCutoff = new Date(
+    now.getTime() - MIN_NOTIFICATION_INTERVAL_MINUTES * 60 * 1000,
+  );
+
+  // Build the AND conditions array
+  const andConditions: object[] = [
+    // Card is due within the notification window
+    {
+      nextReviewDate: {
+        gte: windowStart,
+        lte: windowEnd,
+      },
+    },
+    // Card is not snoozed (or snooze has expired)
+    {
+      OR: [{ snoozedUntil: null }, { snoozedUntil: { lte: now } }],
+    },
+    // User has notifications enabled and has a push token
+    {
+      deck: {
+        user: {
+          notificationsEnabled: true,
+          pushToken: { not: null },
+        },
+      },
+    },
+  ];
+
+  // Add notification filter if needed
+  if (excludeRecentlyNotified) {
+    andConditions.push({
+      OR: [
+        { lastNotificationSent: null },
+        { lastNotificationSent: { lt: recentNotificationCutoff } },
+      ],
+    });
+  }
+
+  const cards = await prisma.card.findMany({
+    where: {
+      AND: andConditions,
+    },
+    select: {
+      id: true,
+      front: true,
+      nextReviewDate: true,
+      lastNotificationSent: true,
+      snoozedUntil: true,
+      deck: {
+        select: {
+          id: true,
+          title: true,
+          userId: true,
+          parentDeckId: true,
+        },
+      },
+    },
+  });
+
+  // Fetch user information for each unique userId
+  const userIds = [...new Set(cards.map((card) => card.deck.userId))];
+  const users = await prisma.user.findMany({
+    where: { id: { in: userIds } },
+    select: {
+      id: true,
+      clerkId: true,
+      pushToken: true,
+      notificationsEnabled: true,
+    },
+  });
+
+  const userMap = new Map(users.map((user) => [user.id, user]));
+
+  // Combine cards with user information
+  return cards
+    .map((card) => {
+      const user = userMap.get(card.deck.userId);
+      if (!user) return null;
+
+      return {
+        ...card,
+        user,
+      };
+    })
+    .filter((card): card is DueCardWithRelations => card !== null);
+}
+
+/**
+ * Counts the number of cards due for review within the notification window.
+ * Useful for quick checks without fetching full card data.
+ *
+ * @param options - Query options
+ * @returns Count of due cards
+ */
+export async function countDueCards(
+  options: FindDueCardsOptions = {},
+): Promise<number> {
+  const {
+    windowMinutes = NOTIFICATION_WINDOW_MINUTES,
+    excludeRecentlyNotified = true,
+  } = options;
+
+  const now = new Date();
+  const windowStart = new Date(now.getTime() - windowMinutes * 60 * 1000);
+  const windowEnd = new Date(now.getTime() + windowMinutes * 60 * 1000);
+  const recentNotificationCutoff = new Date(
+    now.getTime() - MIN_NOTIFICATION_INTERVAL_MINUTES * 60 * 1000,
+  );
+
+  const andConditions: object[] = [
+    {
+      nextReviewDate: {
+        gte: windowStart,
+        lte: windowEnd,
+      },
+    },
+    {
+      OR: [{ snoozedUntil: null }, { snoozedUntil: { lte: now } }],
+    },
+    {
+      deck: {
+        user: {
+          notificationsEnabled: true,
+          pushToken: { not: null },
+        },
+      },
+    },
+  ];
+
+  if (excludeRecentlyNotified) {
+    andConditions.push({
+      OR: [
+        { lastNotificationSent: null },
+        { lastNotificationSent: { lt: recentNotificationCutoff } },
+      ],
+    });
+  }
+
+  return prisma.card.count({
+    where: {
+      AND: andConditions,
+    },
+  });
+}


### PR DESCRIPTION
Closes #22

**Parent Issue:** #20
**Feature Branch PR:** #69

## Summary
Implements a query function to find cards due for review within the ±7 minute notification window.

## Changes
- Add `services/due-cards.ts` with `findDueCards()` and `countDueCards()` functions
- Query cards where `nextReviewDate` is within ±7 minutes of current time
- Exclude cards where `snoozedUntil > now` (user snoozed the card)
- Exclude cards that were notified within the last 30 minutes (via `lastNotificationSent`)
- Only include cards from users with `notificationsEnabled: true` and valid `pushToken`
- Include related deck and user information for notification grouping
- Add comprehensive unit tests

## Schema Note
Uses existing schema fields (`lastNotificationSent`, `snoozedUntil`) instead of the `notified`/`notifiedAt` fields mentioned in the original issue, as the schema has evolved.