### PR TITLE
Implement card grouping logic by user and deck

### DIFF
--- a/apps/server/src/services/__tests__/notification-grouping.test.ts
+++ b/apps/server/src/services/__tests__/notification-grouping.test.ts
@@ -1,0 +1,294 @@
+import {
+  groupCardsByUserAndDeck,
+  generateNotificationMessage,
+  generateNotificationTitle,
+  prepareNotificationPayload,
+  type UserNotificationGroup,
+} from '@/services/notification-grouping';
+import type { DueCardWithRelations } from '@/services/due-cards';
+
+describe('Notification Grouping Service', () => {
+  const now = new Date('2024-01-15T10:00:00.000Z');
+
+  const createMockCard = (
+    id: string,
+    deckId: string,
+    deckTitle: string,
+    userId: string,
+    pushToken: string | null = 'ExponentPushToken[xxx]',
+  ): DueCardWithRelations => ({
+    id,
+    front: `Question ${id}`,
+    nextReviewDate: now,
+    lastNotificationSent: null,
+    snoozedUntil: null,
+    deck: {
+      id: deckId,
+      title: deckTitle,
+      userId,
+      parentDeckId: null,
+    },
+    user: {
+      id: userId,
+      clerkId: `clerk-${userId}`,
+      pushToken,
+      notificationsEnabled: true,
+    },
+  });
+
+  describe('groupCardsByUserAndDeck', () => {
+    it('should group cards by user and deck', () => {
+      const cards: DueCardWithRelations[] = [
+        createMockCard('card-1', 'deck-1', 'Math', 'user-1'),
+        createMockCard('card-2', 'deck-1', 'Math', 'user-1'),
+        createMockCard('card-3', 'deck-2', 'Science', 'user-1'),
+      ];
+
+      const result = groupCardsByUserAndDeck(cards);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].userId).toBe('user-1');
+      expect(result[0].totalCards).toBe(3);
+      expect(result[0].decks).toHaveLength(2);
+
+      const mathDeck = result[0].decks.find((d) => d.deckTitle === 'Math');
+      expect(mathDeck?.cardCount).toBe(2);
+      expect(mathDeck?.cardIds).toEqual(['card-1', 'card-2']);
+
+      const scienceDeck = result[0].decks.find(
+        (d) => d.deckTitle === 'Science',
+      );
+      expect(scienceDeck?.cardCount).toBe(1);
+      expect(scienceDeck?.cardIds).toEqual(['card-3']);
+    });
+
+    it('should handle multiple users', () => {
+      const cards: DueCardWithRelations[] = [
+        createMockCard('card-1', 'deck-1', 'Math', 'user-1', 'token-1'),
+        createMockCard('card-2', 'deck-2', 'Science', 'user-2', 'token-2'),
+      ];
+
+      const result = groupCardsByUserAndDeck(cards);
+
+      expect(result).toHaveLength(2);
+      expect(result.map((r) => r.userId).sort()).toEqual(['user-1', 'user-2']);
+    });
+
+    it('should exclude users without push tokens', () => {
+      const cards: DueCardWithRelations[] = [
+        createMockCard('card-1', 'deck-1', 'Math', 'user-1', 'token-1'),
+        createMockCard('card-2', 'deck-2', 'Science', 'user-2', null), // No push token
+      ];
+
+      const result = groupCardsByUserAndDeck(cards);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].userId).toBe('user-1');
+    });
+
+    it('should return empty array for empty input', () => {
+      const result = groupCardsByUserAndDeck([]);
+      expect(result).toEqual([]);
+    });
+
+    it('should include push token in result', () => {
+      const cards: DueCardWithRelations[] = [
+        createMockCard('card-1', 'deck-1', 'Math', 'user-1', 'my-push-token'),
+      ];
+
+      const result = groupCardsByUserAndDeck(cards);
+
+      expect(result[0].pushToken).toBe('my-push-token');
+    });
+  });
+
+  describe('generateNotificationMessage', () => {
+    it('should generate message for single card in single deck', () => {
+      const group: UserNotificationGroup = {
+        userId: 'user-1',
+        clerkId: 'clerk-1',
+        pushToken: 'token',
+        decks: [
+          {
+            deckId: 'deck-1',
+            deckTitle: 'Math',
+            parentDeckId: null,
+            cardCount: 1,
+            cardIds: ['card-1'],
+          },
+        ],
+        totalCards: 1,
+      };
+
+      expect(generateNotificationMessage(group)).toBe('1 card due in Math');
+    });
+
+    it('should generate message for multiple cards in single deck', () => {
+      const group: UserNotificationGroup = {
+        userId: 'user-1',
+        clerkId: 'clerk-1',
+        pushToken: 'token',
+        decks: [
+          {
+            deckId: 'deck-1',
+            deckTitle: 'Math',
+            parentDeckId: null,
+            cardCount: 3,
+            cardIds: ['card-1', 'card-2', 'card-3'],
+          },
+        ],
+        totalCards: 3,
+      };
+
+      expect(generateNotificationMessage(group)).toBe('3 cards due in Math');
+    });
+
+    it('should generate message for multiple decks', () => {
+      const group: UserNotificationGroup = {
+        userId: 'user-1',
+        clerkId: 'clerk-1',
+        pushToken: 'token',
+        decks: [
+          {
+            deckId: 'deck-1',
+            deckTitle: 'Math',
+            parentDeckId: null,
+            cardCount: 2,
+            cardIds: ['card-1', 'card-2'],
+          },
+          {
+            deckId: 'deck-2',
+            deckTitle: 'Science',
+            parentDeckId: null,
+            cardCount: 1,
+            cardIds: ['card-3'],
+          },
+        ],
+        totalCards: 3,
+      };
+
+      expect(generateNotificationMessage(group)).toBe(
+        '3 cards due: 2 in Math, 1 in Science',
+      );
+    });
+
+    it('should sort decks by card count in message', () => {
+      const group: UserNotificationGroup = {
+        userId: 'user-1',
+        clerkId: 'clerk-1',
+        pushToken: 'token',
+        decks: [
+          {
+            deckId: 'deck-1',
+            deckTitle: 'Math',
+            parentDeckId: null,
+            cardCount: 1,
+            cardIds: ['card-1'],
+          },
+          {
+            deckId: 'deck-2',
+            deckTitle: 'Science',
+            parentDeckId: null,
+            cardCount: 3,
+            cardIds: ['card-2', 'card-3', 'card-4'],
+          },
+        ],
+        totalCards: 4,
+      };
+
+      // Science should come first (3 cards) then Math (1 card)
+      expect(generateNotificationMessage(group)).toBe(
+        '4 cards due: 3 in Science, 1 in Math',
+      );
+    });
+
+    it('should return empty string for zero cards', () => {
+      const group: UserNotificationGroup = {
+        userId: 'user-1',
+        clerkId: 'clerk-1',
+        pushToken: 'token',
+        decks: [],
+        totalCards: 0,
+      };
+
+      expect(generateNotificationMessage(group)).toBe('');
+    });
+  });
+
+  describe('generateNotificationTitle', () => {
+    it('should return "Time to review!" for single card', () => {
+      expect(generateNotificationTitle(1)).toBe('Time to review!');
+    });
+
+    it('should return "Cards ready for review!" for multiple cards', () => {
+      expect(generateNotificationTitle(2)).toBe('Cards ready for review!');
+      expect(generateNotificationTitle(10)).toBe('Cards ready for review!');
+    });
+
+    it('should return "MicroFlash" for zero cards', () => {
+      expect(generateNotificationTitle(0)).toBe('MicroFlash');
+    });
+  });
+
+  describe('prepareNotificationPayload', () => {
+    it('should prepare complete notification payload', () => {
+      const group: UserNotificationGroup = {
+        userId: 'user-1',
+        clerkId: 'clerk-1',
+        pushToken: 'token',
+        decks: [
+          {
+            deckId: 'deck-1',
+            deckTitle: 'Math',
+            parentDeckId: null,
+            cardCount: 2,
+            cardIds: ['card-1', 'card-2'],
+          },
+          {
+            deckId: 'deck-2',
+            deckTitle: 'Science',
+            parentDeckId: null,
+            cardCount: 1,
+            cardIds: ['card-3'],
+          },
+        ],
+        totalCards: 3,
+      };
+
+      const payload = prepareNotificationPayload(group);
+
+      expect(payload.title).toBe('Cards ready for review!');
+      expect(payload.body).toBe('3 cards due: 2 in Math, 1 in Science');
+      expect(payload.data).toEqual({
+        type: 'due_cards',
+        cardIds: ['card-1', 'card-2', 'card-3'],
+        deckIds: ['deck-1', 'deck-2'],
+        totalCards: 3,
+      });
+    });
+
+    it('should handle single card payload', () => {
+      const group: UserNotificationGroup = {
+        userId: 'user-1',
+        clerkId: 'clerk-1',
+        pushToken: 'token',
+        decks: [
+          {
+            deckId: 'deck-1',
+            deckTitle: 'Math',
+            parentDeckId: null,
+            cardCount: 1,
+            cardIds: ['card-1'],
+          },
+        ],
+        totalCards: 1,
+      };
+
+      const payload = prepareNotificationPayload(group);
+
+      expect(payload.title).toBe('Time to review!');
+      expect(payload.body).toBe('1 card due in Math');
+      expect(payload.data.cardIds).toEqual(['card-1']);
+    });
+  });
+});

--- a/apps/server/src/services/notification-grouping.ts
+++ b/apps/server/src/services/notification-grouping.ts
@@ -1,0 +1,186 @@
+import type { DueCardWithRelations } from './due-cards';
+
+/**
+ * Represents a deck with its due card count for notification purposes.
+ */
+export interface DeckCardGroup {
+  deckId: string;
+  deckTitle: string;
+  parentDeckId: string | null;
+  cardCount: number;
+  cardIds: string[];
+}
+
+/**
+ * Represents a user's grouped notification data.
+ */
+export interface UserNotificationGroup {
+  userId: string;
+  clerkId: string;
+  pushToken: string;
+  decks: DeckCardGroup[];
+  totalCards: number;
+}
+
+/**
+ * Groups due cards by user and deck for notification processing.
+ *
+ * @param cards - Array of due cards with user and deck relations
+ * @returns Array of user notification groups, excluding users without push tokens
+ */
+export function groupCardsByUserAndDeck(
+  cards: DueCardWithRelations[],
+): UserNotificationGroup[] {
+  // Group by user first
+  const userMap = new Map<
+    string,
+    {
+      userId: string;
+      clerkId: string;
+      pushToken: string | null;
+      deckMap: Map<string, DeckCardGroup>;
+    }
+  >();
+
+  for (const card of cards) {
+    const { user, deck } = card;
+
+    // Get or create user entry
+    let userEntry = userMap.get(user.id);
+    if (!userEntry) {
+      userEntry = {
+        userId: user.id,
+        clerkId: user.clerkId,
+        pushToken: user.pushToken,
+        deckMap: new Map(),
+      };
+      userMap.set(user.id, userEntry);
+    }
+
+    // Get or create deck entry within user
+    let deckEntry = userEntry.deckMap.get(deck.id);
+    if (!deckEntry) {
+      deckEntry = {
+        deckId: deck.id,
+        deckTitle: deck.title,
+        parentDeckId: deck.parentDeckId,
+        cardCount: 0,
+        cardIds: [],
+      };
+      userEntry.deckMap.set(deck.id, deckEntry);
+    }
+
+    // Add card to deck
+    deckEntry.cardCount++;
+    deckEntry.cardIds.push(card.id);
+  }
+
+  // Convert to array format, filtering out users without push tokens
+  const result: UserNotificationGroup[] = [];
+
+  for (const userEntry of userMap.values()) {
+    // Skip users without push tokens
+    if (!userEntry.pushToken) {
+      continue;
+    }
+
+    const decks = Array.from(userEntry.deckMap.values());
+    const totalCards = decks.reduce((sum, deck) => sum + deck.cardCount, 0);
+
+    result.push({
+      userId: userEntry.userId,
+      clerkId: userEntry.clerkId,
+      pushToken: userEntry.pushToken,
+      decks,
+      totalCards,
+    });
+  }
+
+  return result;
+}
+
+/**
+ * Generates a human-readable notification message for a user's due cards.
+ *
+ * Examples:
+ * - "1 card due in Math"
+ * - "3 cards due in Math"
+ * - "5 cards due: 3 in Math, 2 in Science"
+ * - "7 cards due: 3 in Math, 2 in Science, 2 in History"
+ *
+ * @param group - User notification group
+ * @returns Notification message string, or empty string if no cards
+ */
+export function generateNotificationMessage(
+  group: UserNotificationGroup,
+): string {
+  if (group.totalCards === 0 || group.decks.length === 0) {
+    return '';
+  }
+
+  const cardWord = group.totalCards === 1 ? 'card' : 'cards';
+
+  // Single deck case
+  if (group.decks.length === 1) {
+    const deck = group.decks[0];
+    return `${group.totalCards} ${cardWord} due in ${deck.deckTitle}`;
+  }
+
+  // Multiple decks case
+  // Sort decks by card count (descending) for more meaningful message
+  const sortedDecks = [...group.decks].sort(
+    (a, b) => b.cardCount - a.cardCount,
+  );
+
+  const deckParts = sortedDecks.map(
+    (deck) => `${deck.cardCount} in ${deck.deckTitle}`,
+  );
+
+  return `${group.totalCards} ${cardWord} due: ${deckParts.join(', ')}`;
+}
+
+/**
+ * Generates a notification title based on the number of due cards.
+ *
+ * @param totalCards - Total number of due cards
+ * @returns Notification title string
+ */
+export function generateNotificationTitle(totalCards: number): string {
+  if (totalCards === 0) {
+    return 'MicroFlash';
+  }
+
+  if (totalCards === 1) {
+    return 'Time to review!';
+  }
+
+  return 'Cards ready for review!';
+}
+
+/**
+ * Prepares notification data for a user group.
+ *
+ * @param group - User notification group
+ * @returns Object with title, body, and data for the push notification
+ */
+export function prepareNotificationPayload(group: UserNotificationGroup): {
+  title: string;
+  body: string;
+  data: {
+    type: 'due_cards';
+    cardIds: string[];
+    deckIds: string[];
+    totalCards: number;
+  };
+} {
+  return {
+    title: generateNotificationTitle(group.totalCards),
+    body: generateNotificationMessage(group),
+    data: {
+      type: 'due_cards',
+      cardIds: group.decks.flatMap((deck) => deck.cardIds),
+      deckIds: group.decks.map((deck) => deck.deckId),
+      totalCards: group.totalCards,
+    },
+  };
+}


### PR DESCRIPTION
Closes #23

**Parent Issue:** #20
**Feature Branch PR:** #69

## Summary
Implements card grouping logic to organize due cards by user and deck for generating meaningful push notifications.

## Changes
- Add `services/notification-grouping.ts` with grouping and message generation functions
- `groupCardsByUserAndDeck()` - Groups cards by user, then by deck within each user
- `generateNotificationMessage()` - Creates human-readable notification body
  - Single deck: "3 cards due in Math"
  - Multiple decks: "5 cards due: 3 in Math, 2 in Science"
  - Sorts decks by card count (descending) for more meaningful messages
- `generateNotificationTitle()` - Creates contextual notification title
- `prepareNotificationPayload()` - Prepares complete notification data with title, body, and metadata
- Excludes users without push tokens from grouping
- Add comprehensive unit tests (15 test cases)