### PR TITLE
Integrate Expo Push Notification service

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -26,6 +26,7 @@
     "@microflash/shared": "workspace:*",
     "@prisma/client": "^6.1.0",
     "cors": "^2.8.5",
+    "expo-server-sdk": "^4.0.0",
     "express": "^4.21.1",
     "node-cron": "^3.0.3",
     "zod": "^4.3.5"

--- a/apps/server/src/services/__tests__/push-notifications.test.ts
+++ b/apps/server/src/services/__tests__/push-notifications.test.ts
@@ -1,0 +1,270 @@
+import {
+  isValidExpoPushToken,
+  sendPushNotification,
+  sendBatchNotifications,
+  checkPushNotificationReceipts,
+  logNotificationResults,
+  getExpoClient,
+  resetExpoClient,
+} from '@/services/push-notifications';
+
+// Mock expo-server-sdk
+jest.mock('expo-server-sdk', () => {
+  const mockExpo = {
+    sendPushNotificationsAsync: jest.fn(),
+    getPushNotificationReceiptsAsync: jest.fn(),
+    chunkPushNotifications: jest.fn((messages) => [messages]),
+    chunkPushNotificationReceiptIds: jest.fn((ids) => [ids]),
+  };
+
+  const MockExpo = jest.fn(() => mockExpo);
+  (MockExpo as any).isExpoPushToken = jest.fn(
+    (token: string) =>
+      typeof token === 'string' && token.startsWith('ExponentPushToken['),
+  );
+
+  return {
+    __esModule: true,
+    default: MockExpo,
+  };
+});
+
+describe('Push Notifications Service', () => {
+  let mockExpo: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetExpoClient();
+    // Get the mock instance
+    mockExpo = getExpoClient();
+  });
+
+  describe('isValidExpoPushToken', () => {
+    it('should return true for valid Expo push tokens', () => {
+      expect(isValidExpoPushToken('ExponentPushToken[xxx]')).toBe(true);
+      expect(isValidExpoPushToken('ExponentPushToken[abc123]')).toBe(true);
+    });
+
+    it('should return false for invalid tokens', () => {
+      expect(isValidExpoPushToken('')).toBe(false);
+      expect(isValidExpoPushToken('invalid-token')).toBe(false);
+      expect(isValidExpoPushToken('FCM-token-123')).toBe(false);
+    });
+  });
+
+  describe('sendPushNotification', () => {
+    it('should send a notification successfully', async () => {
+      mockExpo.sendPushNotificationsAsync.mockResolvedValue([
+        { status: 'ok', id: 'ticket-123' },
+      ]);
+
+      const result = await sendPushNotification(
+        'ExponentPushToken[xxx]',
+        'Test Title',
+        'Test Body',
+        { key: 'value' },
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.ticketId).toBe('ticket-123');
+      expect(result.pushToken).toBe('ExponentPushToken[xxx]');
+    });
+
+    it('should return error for invalid token', async () => {
+      const result = await sendPushNotification(
+        'invalid-token',
+        'Test Title',
+        'Test Body',
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Invalid Expo push token');
+      expect(mockExpo.sendPushNotificationsAsync).not.toHaveBeenCalled();
+    });
+
+    it('should handle API errors', async () => {
+      mockExpo.sendPushNotificationsAsync.mockResolvedValue([
+        { status: 'error', message: 'DeviceNotRegistered' },
+      ]);
+
+      const result = await sendPushNotification(
+        'ExponentPushToken[xxx]',
+        'Test Title',
+        'Test Body',
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('DeviceNotRegistered');
+    });
+
+    it('should handle exceptions', async () => {
+      mockExpo.sendPushNotificationsAsync.mockRejectedValue(
+        new Error('Network error'),
+      );
+
+      const result = await sendPushNotification(
+        'ExponentPushToken[xxx]',
+        'Test Title',
+        'Test Body',
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Network error');
+    });
+  });
+
+  describe('sendBatchNotifications', () => {
+    it('should send multiple notifications', async () => {
+      mockExpo.sendPushNotificationsAsync.mockResolvedValue([
+        { status: 'ok', id: 'ticket-1' },
+        { status: 'ok', id: 'ticket-2' },
+      ]);
+
+      const notifications = [
+        {
+          pushToken: 'ExponentPushToken[aaa]',
+          title: 'Title 1',
+          body: 'Body 1',
+        },
+        {
+          pushToken: 'ExponentPushToken[bbb]',
+          title: 'Title 2',
+          body: 'Body 2',
+        },
+      ];
+
+      const results = await sendBatchNotifications(notifications);
+
+      expect(results).toHaveLength(2);
+      expect(results[0].success).toBe(true);
+      expect(results[1].success).toBe(true);
+    });
+
+    it('should filter out invalid tokens', async () => {
+      mockExpo.sendPushNotificationsAsync.mockResolvedValue([
+        { status: 'ok', id: 'ticket-1' },
+      ]);
+
+      const notifications = [
+        {
+          pushToken: 'ExponentPushToken[aaa]',
+          title: 'Title 1',
+          body: 'Body 1',
+        },
+        { pushToken: 'invalid-token', title: 'Title 2', body: 'Body 2' },
+      ];
+
+      const results = await sendBatchNotifications(notifications);
+
+      expect(results).toHaveLength(2);
+      expect(
+        results.find((r) => r.pushToken === 'invalid-token')?.success,
+      ).toBe(false);
+      expect(
+        results.find((r) => r.pushToken === 'ExponentPushToken[aaa]')?.success,
+      ).toBe(true);
+    });
+
+    it('should return empty array for empty input', async () => {
+      const results = await sendBatchNotifications([]);
+      expect(results).toEqual([]);
+    });
+
+    it('should handle mixed success and failure', async () => {
+      mockExpo.sendPushNotificationsAsync.mockResolvedValue([
+        { status: 'ok', id: 'ticket-1' },
+        { status: 'error', message: 'DeviceNotRegistered' },
+      ]);
+
+      const notifications = [
+        {
+          pushToken: 'ExponentPushToken[aaa]',
+          title: 'Title 1',
+          body: 'Body 1',
+        },
+        {
+          pushToken: 'ExponentPushToken[bbb]',
+          title: 'Title 2',
+          body: 'Body 2',
+        },
+      ];
+
+      const results = await sendBatchNotifications(notifications);
+
+      expect(results[0].success).toBe(true);
+      expect(results[1].success).toBe(false);
+      expect(results[1].error).toBe('DeviceNotRegistered');
+    });
+  });
+
+  describe('checkPushNotificationReceipts', () => {
+    it('should check receipts successfully', async () => {
+      mockExpo.getPushNotificationReceiptsAsync.mockResolvedValue({
+        'receipt-1': { status: 'ok' },
+        'receipt-2': { status: 'ok' },
+      });
+
+      const results = await checkPushNotificationReceipts([
+        'receipt-1',
+        'receipt-2',
+      ]);
+
+      expect(results).toHaveLength(2);
+      expect(results[0].status).toBe('ok');
+      expect(results[1].status).toBe('ok');
+    });
+
+    it('should handle DeviceNotRegistered errors', async () => {
+      mockExpo.getPushNotificationReceiptsAsync.mockResolvedValue({
+        'receipt-1': {
+          status: 'error',
+          message: 'Device not registered',
+          details: { error: 'DeviceNotRegistered' },
+        },
+      });
+
+      const results = await checkPushNotificationReceipts(['receipt-1']);
+
+      expect(results[0].status).toBe('error');
+      expect(results[0].shouldRemoveToken).toBe(true);
+    });
+
+    it('should return empty array for empty input', async () => {
+      const results = await checkPushNotificationReceipts([]);
+      expect(results).toEqual([]);
+    });
+
+    it('should handle missing receipts', async () => {
+      mockExpo.getPushNotificationReceiptsAsync.mockResolvedValue({});
+
+      const results = await checkPushNotificationReceipts(['receipt-1']);
+
+      expect(results[0].status).toBe('error');
+      expect(results[0].error).toBe('Receipt not found');
+    });
+  });
+
+  describe('logNotificationResults', () => {
+    it('should log results without throwing', () => {
+      const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      const results = [
+        { pushToken: 'token-1', success: true, ticketId: 'ticket-1' },
+        { pushToken: 'token-2', success: false, error: 'Failed' },
+      ];
+
+      expect(() => logNotificationResults(results)).not.toThrow();
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('1 successful, 1 failed'),
+      );
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to send to token-2'),
+      );
+
+      consoleSpy.mockRestore();
+      consoleErrorSpy.mockRestore();
+    });
+  });
+});

--- a/apps/server/src/services/push-notifications.ts
+++ b/apps/server/src/services/push-notifications.ts
@@ -1,0 +1,332 @@
+import Expo, {
+  type ExpoPushMessage,
+  type ExpoPushTicket,
+  type ExpoPushReceipt,
+  type ExpoPushSuccessTicket,
+} from 'expo-server-sdk';
+
+/**
+ * Result of sending a single push notification.
+ */
+export interface PushNotificationResult {
+  pushToken: string;
+  success: boolean;
+  ticketId?: string;
+  error?: string;
+}
+
+/**
+ * Result of checking a push notification receipt.
+ */
+export interface ReceiptCheckResult {
+  receiptId: string;
+  status: 'ok' | 'error';
+  error?: string;
+  shouldRemoveToken?: boolean;
+}
+
+// Create Expo client singleton
+let expoClient: Expo | null = null;
+
+/**
+ * Gets or creates the Expo client singleton.
+ * Uses EXPO_ACCESS_TOKEN if available for authenticated requests.
+ */
+export function getExpoClient(): Expo {
+  if (!expoClient) {
+    const accessToken = process.env.EXPO_ACCESS_TOKEN;
+    expoClient = new Expo({
+      accessToken: accessToken || undefined,
+    });
+  }
+  return expoClient;
+}
+
+/**
+ * Resets the Expo client (useful for testing).
+ */
+export function resetExpoClient(): void {
+  expoClient = null;
+}
+
+/**
+ * Validates whether a string is a valid Expo push token.
+ *
+ * @param token - The token to validate
+ * @returns true if the token is a valid Expo push token
+ */
+export function isValidExpoPushToken(token: string): boolean {
+  return Expo.isExpoPushToken(token);
+}
+
+/**
+ * Sends a single push notification.
+ *
+ * @param pushToken - The Expo push token to send to
+ * @param title - Notification title
+ * @param body - Notification body
+ * @param data - Optional data payload
+ * @returns Result indicating success or failure
+ */
+export async function sendPushNotification(
+  pushToken: string,
+  title: string,
+  body: string,
+  data?: Record<string, unknown>,
+): Promise<PushNotificationResult> {
+  if (!isValidExpoPushToken(pushToken)) {
+    return {
+      pushToken,
+      success: false,
+      error: 'Invalid Expo push token',
+    };
+  }
+
+  const expo = getExpoClient();
+
+  const message: ExpoPushMessage = {
+    to: pushToken,
+    sound: 'default',
+    title,
+    body,
+    data: data || {},
+  };
+
+  try {
+    const tickets = await expo.sendPushNotificationsAsync([message]);
+    const ticket = tickets[0];
+
+    if (ticket.status === 'ok') {
+      return {
+        pushToken,
+        success: true,
+        ticketId: (ticket as ExpoPushSuccessTicket).id,
+      };
+    } else {
+      return {
+        pushToken,
+        success: false,
+        error: ticket.message || 'Unknown error',
+      };
+    }
+  } catch (error) {
+    const errorMessage =
+      error instanceof Error ? error.message : 'Unknown error';
+    console.error('[PushNotifications] Error sending notification:', error);
+    return {
+      pushToken,
+      success: false,
+      error: errorMessage,
+    };
+  }
+}
+
+/**
+ * Sends push notifications to multiple users in batches.
+ * Uses Expo's chunking to optimize API requests.
+ *
+ * @param notifications - Array of notifications to send
+ * @returns Array of results for each notification
+ */
+export async function sendBatchNotifications(
+  notifications: Array<{
+    pushToken: string;
+    title: string;
+    body: string;
+    data?: Record<string, unknown>;
+  }>,
+): Promise<PushNotificationResult[]> {
+  if (notifications.length === 0) {
+    return [];
+  }
+
+  const expo = getExpoClient();
+  const results: PushNotificationResult[] = [];
+
+  // Filter out invalid tokens and track them
+  const validNotifications: Array<{
+    pushToken: string;
+    title: string;
+    body: string;
+    data?: Record<string, unknown>;
+  }> = [];
+
+  for (const notification of notifications) {
+    if (!isValidExpoPushToken(notification.pushToken)) {
+      results.push({
+        pushToken: notification.pushToken,
+        success: false,
+        error: 'Invalid Expo push token',
+      });
+    } else {
+      validNotifications.push(notification);
+    }
+  }
+
+  if (validNotifications.length === 0) {
+    return results;
+  }
+
+  // Build messages
+  const messages: ExpoPushMessage[] = validNotifications.map((n) => ({
+    to: n.pushToken,
+    sound: 'default' as const,
+    title: n.title,
+    body: n.body,
+    data: n.data || {},
+  }));
+
+  // Chunk messages for efficient sending
+  const chunks = expo.chunkPushNotifications(messages);
+
+  // Track which token corresponds to which index
+  const tokenIndexMap = new Map<string, number>();
+  validNotifications.forEach((n, i) => {
+    tokenIndexMap.set(n.pushToken, i);
+  });
+
+  // Send each chunk
+  let ticketIndex = 0;
+  for (const chunk of chunks) {
+    try {
+      const tickets = await expo.sendPushNotificationsAsync(chunk);
+
+      for (let i = 0; i < tickets.length; i++) {
+        const ticket = tickets[i];
+        const notification = validNotifications[ticketIndex + i];
+
+        if (ticket.status === 'ok') {
+          results.push({
+            pushToken: notification.pushToken,
+            success: true,
+            ticketId: (ticket as ExpoPushSuccessTicket).id,
+          });
+        } else {
+          results.push({
+            pushToken: notification.pushToken,
+            success: false,
+            error: ticket.message || 'Unknown error',
+          });
+        }
+      }
+
+      ticketIndex += tickets.length;
+    } catch (error) {
+      // If a chunk fails, mark all notifications in that chunk as failed
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
+      console.error('[PushNotifications] Error sending chunk:', error);
+
+      for (let i = 0; i < chunk.length; i++) {
+        const notification = validNotifications[ticketIndex + i];
+        if (notification) {
+          results.push({
+            pushToken: notification.pushToken,
+            success: false,
+            error: errorMessage,
+          });
+        }
+      }
+
+      ticketIndex += chunk.length;
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Checks push notification receipts to verify delivery.
+ * Should be called after a delay (e.g., 15-30 seconds) to allow delivery.
+ *
+ * @param receiptIds - Array of receipt IDs from successful ticket sends
+ * @returns Array of receipt check results
+ */
+export async function checkPushNotificationReceipts(
+  receiptIds: string[],
+): Promise<ReceiptCheckResult[]> {
+  if (receiptIds.length === 0) {
+    return [];
+  }
+
+  const expo = getExpoClient();
+  const results: ReceiptCheckResult[] = [];
+
+  // Chunk receipt IDs for efficient fetching
+  const chunks = expo.chunkPushNotificationReceiptIds(receiptIds);
+
+  for (const chunk of chunks) {
+    try {
+      const receipts = await expo.getPushNotificationReceiptsAsync(chunk);
+
+      for (const receiptId of chunk) {
+        const receipt = receipts[receiptId];
+
+        if (!receipt) {
+          results.push({
+            receiptId,
+            status: 'error',
+            error: 'Receipt not found',
+          });
+          continue;
+        }
+
+        if (receipt.status === 'ok') {
+          results.push({
+            receiptId,
+            status: 'ok',
+          });
+        } else {
+          const errorDetails = receipt.details?.error;
+          results.push({
+            receiptId,
+            status: 'error',
+            error: receipt.message || errorDetails || 'Unknown error',
+            // DeviceNotRegistered means the token should be removed
+            shouldRemoveToken: errorDetails === 'DeviceNotRegistered',
+          });
+        }
+      }
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
+      console.error('[PushNotifications] Error fetching receipts:', error);
+
+      // Mark all receipts in this chunk as errored
+      for (const receiptId of chunk) {
+        results.push({
+          receiptId,
+          status: 'error',
+          error: errorMessage,
+        });
+      }
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Logs notification results for monitoring.
+ *
+ * @param results - Array of push notification results
+ */
+export function logNotificationResults(
+  results: PushNotificationResult[],
+): void {
+  const successful = results.filter((r) => r.success).length;
+  const failed = results.filter((r) => !r.success).length;
+
+  console.log(
+    `[PushNotifications] Sent ${results.length} notifications: ${successful} successful, ${failed} failed`,
+  );
+
+  // Log individual failures for debugging
+  for (const result of results) {
+    if (!result.success) {
+      console.error(
+        `[PushNotifications] Failed to send to ${result.pushToken}: ${result.error}`,
+      );
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,7 +70,7 @@ importers:
         version: 54.0.13(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.12)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       expo-constants:
         specifier: ~18.0.9
-        version: 18.0.9(expo@54.0.13)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))
+        version: 18.0.9(expo@54.0.13(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.12)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))
       expo-font:
         specifier: ~14.0.9
         version: 14.0.9(expo@54.0.13(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.12)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -177,6 +177,9 @@ importers:
       cors:
         specifier: ^2.8.5
         version: 2.8.5
+      expo-server-sdk:
+        specifier: ^4.0.0
+        version: 4.0.0
       express:
         specifier: ^4.21.1
         version: 4.21.2
@@ -2888,6 +2891,9 @@ packages:
     resolution: {integrity: sha512-ObFo8v4rQJAE59M69QzwloxPZtd33TpYEIjtKD1rrFDcM1Gd7IkDxEBU+HriziN6HSHQnBJi8Dmy+JWkav5HKA==}
     engines: {node: '>=8'}
 
+  err-code@2.0.3:
+    resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
+
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
@@ -3213,6 +3219,10 @@ packages:
     resolution: {integrity: sha512-lHnzvRajBu4u+P99+0GEMijQMFCOYpWRO4dWsXSuMt77+THPIGjzNvVKrGSl6mMrLsfVaKL8BpwYZLGlgA+zAw==}
     peerDependencies:
       expo: '*'
+
+  expo-server-sdk@4.0.0:
+    resolution: {integrity: sha512-zi83XtG2pqyP3gyn1JIRYkydo2i6HU3CYaWo/VvhZG/F29U+QIDv6LBEUsWf4ddZlVE7c9WN1N8Be49rHgO8OQ==}
+    engines: {node: '>=20'}
 
   expo-server@1.0.1:
     resolution: {integrity: sha512-J3JlpzNXOkkr4BbapTrcv6klBQcw6NzrBBVIU7qkNE2eU3U1on9rp27wi0+cihjG/QgxSIqQVkrga5z3HWnH0A==}
@@ -4899,6 +4909,13 @@ packages:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
 
+  promise-limit@2.7.0:
+    resolution: {integrity: sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw==}
+
+  promise-retry@2.0.1:
+    resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
+    engines: {node: '>=10'}
+
   promise@7.3.1:
     resolution: {integrity: sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==}
 
@@ -5195,6 +5212,10 @@ packages:
   restore-cursor@2.0.0:
     resolution: {integrity: sha512-6IzJLuGi4+R14vwagDHX+JrXmPVtPpn4mffDJ1UdR7/Edm87fl6yi8mMBIVvFtJaNTUvjughmW4hwLhRG7gC1Q==}
     engines: {node: '>=4'}
+
+  retry@0.12.0:
+    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
 
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
@@ -9305,6 +9326,8 @@ snapshots:
 
   env-editor@0.4.2: {}
 
+  err-code@2.0.3: {}
+
   error-ex@1.3.4:
     dependencies:
       is-arrayish: 0.2.1
@@ -9696,13 +9719,13 @@ snapshots:
     dependencies:
       '@expo/image-utils': 0.8.7
       expo: 54.0.13(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.12)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
-      expo-constants: 18.0.9(expo@54.0.13)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))
+      expo-constants: 18.0.9(expo@54.0.13(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.12)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))
       react: 19.1.0
       react-native: 0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0)
     transitivePeerDependencies:
       - supports-color
 
-  expo-constants@18.0.9(expo@54.0.13)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0)):
+  expo-constants@18.0.9(expo@54.0.13(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.12)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0)):
     dependencies:
       '@expo/config': 12.0.10
       '@expo/env': 2.0.7
@@ -9742,7 +9765,7 @@ snapshots:
 
   expo-linking@8.0.8(expo@54.0.13)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
-      expo-constants: 18.0.9(expo@54.0.13)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))
+      expo-constants: 18.0.9(expo@54.0.13(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.12)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))
       invariant: 2.2.4
       react: 19.1.0
       react-native: 0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0)
@@ -9778,7 +9801,7 @@ snapshots:
       debug: 4.4.3
       escape-string-regexp: 4.0.0
       expo: 54.0.13(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.12)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
-      expo-constants: 18.0.9(expo@54.0.13)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))
+      expo-constants: 18.0.9(expo@54.0.13(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.12)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))
       expo-linking: 8.0.8(expo@54.0.13)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       expo-server: 1.0.1
       fast-deep-equal: 3.1.3
@@ -9812,6 +9835,14 @@ snapshots:
   expo-secure-store@15.0.8(expo@54.0.13(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.12)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)):
     dependencies:
       expo: 54.0.13(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.12)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+
+  expo-server-sdk@4.0.0:
+    dependencies:
+      node-fetch: 2.7.0
+      promise-limit: 2.7.0
+      promise-retry: 2.0.1
+    transitivePeerDependencies:
+      - encoding
 
   expo-server@1.0.1: {}
 
@@ -9864,7 +9895,7 @@ snapshots:
       '@ungap/structured-clone': 1.3.0
       babel-preset-expo: 54.0.4(@babel/core@7.28.4)(@babel/runtime@7.28.4)(expo@54.0.13(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.12)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-refresh@0.14.2)
       expo-asset: 12.0.9(expo@54.0.13(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.12)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
-      expo-constants: 18.0.9(expo@54.0.13)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))
+      expo-constants: 18.0.9(expo@54.0.13(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.12)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))
       expo-file-system: 19.0.17(expo@54.0.13(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.12)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))
       expo-font: 14.0.9(expo@54.0.13(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.12)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       expo-keep-awake: 15.0.7(expo@54.0.13(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.12)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react@19.1.0)
@@ -12163,6 +12194,13 @@ snapshots:
 
   progress@2.0.3: {}
 
+  promise-limit@2.7.0: {}
+
+  promise-retry@2.0.1:
+    dependencies:
+      err-code: 2.0.3
+      retry: 0.12.0
+
   promise@7.3.1:
     dependencies:
       asap: 2.0.6
@@ -12525,6 +12563,8 @@ snapshots:
     dependencies:
       onetime: 2.0.1
       signal-exit: 3.0.7
+
+  retry@0.12.0: {}
 
   reusify@1.1.0: {}
 


### PR DESCRIPTION
Closes #24

**Parent Issue:** #20
**Feature Branch PR:** #69

## Summary
Integrates the Expo Push Notification service for sending push notifications to users via the Expo Push API.

## Changes
- Install `expo-server-sdk` package
- Add `services/push-notifications.ts` with Expo client singleton
- `isValidExpoPushToken()` - Validates Expo push token format
- `sendPushNotification()` - Sends single push notification
- `sendBatchNotifications()` - Sends multiple notifications with automatic chunking
- `checkPushNotificationReceipts()` - Verifies notification delivery via receipts
- `logNotificationResults()` - Logs notification results for monitoring
- Support `EXPO_ACCESS_TOKEN` environment variable for authenticated requests
- Handle `DeviceNotRegistered` errors with `shouldRemoveToken` flag
- Add comprehensive unit tests (15 test cases)

## Environment Variables
- `EXPO_ACCESS_TOKEN` (optional) - Expo access token for authenticated push requests