### PR TITLE
Implement function to mark cards as notified in database

### DIFF
--- a/apps/server/src/routes/notifications.test.ts
+++ b/apps/server/src/routes/notifications.test.ts
@@ -1,48 +1,250 @@
 import request from 'supertest';
 import express from 'express';
+import { ZodError } from 'zod';
 import notificationsRouter from '@/routes/notifications';
+import { prisma } from '@/lib/prisma';
+import { isValidExpoPushToken } from '@/services/push-notifications';
+
+// Mock dependencies
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    user: {
+      update: jest.fn(),
+      findUnique: jest.fn(),
+    },
+    card: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('@/services/push-notifications', () => ({
+  isValidExpoPushToken: jest.fn(),
+}));
+
+jest.mock('@/middlewares/auth', () => ({
+  requireUser: (
+    req: express.Request,
+    _res: express.Response,
+    next: express.NextFunction,
+  ) => {
+    req.user = {
+      id: 'user-1',
+      clerkId: 'clerk-1',
+      pushToken: 'ExponentPushToken[xxx]',
+      notificationsEnabled: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    next();
+  },
+}));
+
+const mockPrisma = prisma as jest.Mocked<typeof prisma>;
+const mockIsValidExpoPushToken = isValidExpoPushToken as jest.MockedFunction<
+  typeof isValidExpoPushToken
+>;
 
 // Create a test app with the router
 const app = express();
 app.use(express.json());
 app.use('/api/notifications', notificationsRouter);
 
-// Add 404 handler
-app.use((_req, res) => {
-  res.status(404).json({ error: 'Route not found' });
-});
+// Add error handler
+app.use(
+  (
+    err: Error,
+    _req: express.Request,
+    res: express.Response,
+    _next: express.NextFunction,
+  ) => {
+    // Handle Zod validation errors
+    if (err instanceof ZodError) {
+      res.status(400).json({
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Invalid request data',
+        },
+      });
+      return;
+    }
 
-describe('Notifications Routes - Unit Tests', () => {
+    const statusCode = (err as any).statusCode || 500;
+    res.status(statusCode).json({
+      error: {
+        code: (err as any).code || 'INTERNAL_ERROR',
+        message: err.message,
+      },
+    });
+  },
+);
+
+describe('Notifications Routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   describe('POST /api/notifications/register', () => {
-    it('should return 200 for register push token (stub)', async () => {
+    it('should register a valid push token', async () => {
+      mockIsValidExpoPushToken.mockReturnValue(true);
+      (mockPrisma.user.update as jest.Mock).mockResolvedValue({
+        id: 'user-1',
+        pushToken: 'ExponentPushToken[xxx]',
+      });
+
       const response = await request(app)
         .post('/api/notifications/register')
         .send({ pushToken: 'ExponentPushToken[xxx]' });
 
       expect(response.status).toBe(200);
-      expect(response.body).toHaveProperty('message');
+      expect(response.body.success).toBe(true);
+      expect(mockPrisma.user.update).toHaveBeenCalledWith({
+        where: { id: 'user-1' },
+        data: { pushToken: 'ExponentPushToken[xxx]' },
+      });
+    });
+
+    it('should reject invalid push token format', async () => {
+      mockIsValidExpoPushToken.mockReturnValue(false);
+
+      const response = await request(app)
+        .post('/api/notifications/register')
+        .send({ pushToken: 'invalid-token' });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error.code).toBe('INVALID_PUSH_TOKEN');
+    });
+
+    it('should require push token in body', async () => {
+      const response = await request(app)
+        .post('/api/notifications/register')
+        .send({});
+
+      expect(response.status).toBe(400);
     });
   });
 
-  describe('POST /api/notifications/:id/snooze', () => {
-    it('should return 200 for snooze notification (stub)', async () => {
+  describe('POST /api/notifications/cards/:id/snooze', () => {
+    it('should snooze a card', async () => {
+      (mockPrisma.card.findUnique as jest.Mock).mockResolvedValue({
+        id: 'card-1',
+        deck: { userId: 'user-1' },
+      });
+      (mockPrisma.card.update as jest.Mock).mockResolvedValue({
+        id: 'card-1',
+        snoozedUntil: new Date(),
+      });
+
       const response = await request(app)
-        .post('/api/notifications/notif-123/snooze')
+        .post('/api/notifications/cards/card-1/snooze')
         .send({ duration: 30 });
 
       expect(response.status).toBe(200);
-      expect(response.body).toHaveProperty('message');
+      expect(response.body.success).toBe(true);
+      expect(response.body.snoozedUntil).toBeDefined();
+    });
+
+    it('should return 404 for non-existent card', async () => {
+      (mockPrisma.card.findUnique as jest.Mock).mockResolvedValue(null);
+
+      const response = await request(app)
+        .post('/api/notifications/cards/non-existent/snooze')
+        .send({ duration: 30 });
+
+      expect(response.status).toBe(404);
+      expect(response.body.error.code).toBe('CARD_NOT_FOUND');
+    });
+
+    it('should return 403 for card owned by another user', async () => {
+      (mockPrisma.card.findUnique as jest.Mock).mockResolvedValue({
+        id: 'card-1',
+        deck: { userId: 'other-user' },
+      });
+
+      const response = await request(app)
+        .post('/api/notifications/cards/card-1/snooze')
+        .send({ duration: 30 });
+
+      expect(response.status).toBe(403);
+      expect(response.body.error.code).toBe('FORBIDDEN');
+    });
+
+    it('should use default duration of 30 minutes', async () => {
+      (mockPrisma.card.findUnique as jest.Mock).mockResolvedValue({
+        id: 'card-1',
+        deck: { userId: 'user-1' },
+      });
+      (mockPrisma.card.update as jest.Mock).mockResolvedValue({
+        id: 'card-1',
+        snoozedUntil: new Date(),
+      });
+
+      const response = await request(app)
+        .post('/api/notifications/cards/card-1/snooze')
+        .send({});
+
+      expect(response.status).toBe(200);
+      expect(response.body.message).toContain('30 minutes');
+    });
+  });
+
+  describe('DELETE /api/notifications/cards/:id/snooze', () => {
+    it('should unsnooze a card', async () => {
+      (mockPrisma.card.findUnique as jest.Mock).mockResolvedValue({
+        id: 'card-1',
+        deck: { userId: 'user-1' },
+      });
+      (mockPrisma.card.update as jest.Mock).mockResolvedValue({
+        id: 'card-1',
+        snoozedUntil: null,
+      });
+
+      const response = await request(app).delete(
+        '/api/notifications/cards/card-1/snooze',
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(mockPrisma.card.update).toHaveBeenCalledWith({
+        where: { id: 'card-1' },
+        data: { snoozedUntil: null },
+      });
     });
   });
 
   describe('PATCH /api/notifications/preferences', () => {
-    it('should return 200 for update preferences (stub)', async () => {
+    it('should update notification preferences', async () => {
+      (mockPrisma.user.update as jest.Mock).mockResolvedValue({
+        id: 'user-1',
+        notificationsEnabled: false,
+      });
+
       const response = await request(app)
         .patch('/api/notifications/preferences')
-        .send({ enabled: true });
+        .send({ notificationsEnabled: false });
 
       expect(response.status).toBe(200);
-      expect(response.body).toHaveProperty('message');
+      expect(response.body.success).toBe(true);
+      expect(response.body.notificationsEnabled).toBe(false);
+    });
+
+    it('should require notificationsEnabled in body', async () => {
+      const response = await request(app)
+        .patch('/api/notifications/preferences')
+        .send({});
+
+      expect(response.status).toBe(400);
+    });
+  });
+
+  describe('GET /api/notifications/preferences', () => {
+    it('should return notification preferences', async () => {
+      const response = await request(app).get('/api/notifications/preferences');
+
+      expect(response.status).toBe(200);
+      expect(response.body.notificationsEnabled).toBe(true);
+      expect(response.body.hasPushToken).toBe(true);
     });
   });
 });

--- a/apps/server/src/routes/notifications.ts
+++ b/apps/server/src/routes/notifications.ts
@@ -1,26 +1,188 @@
 import { Router, type Router as RouterType } from 'express';
+import { z } from 'zod';
+import { prisma } from '@/lib/prisma';
+import { requireUser } from '@/middlewares/auth';
+import { validate } from '@/middlewares/validate';
+import { asyncHandler, ApiError } from '@/middlewares/error-handler';
+import { isValidExpoPushToken } from '@/services/push-notifications';
 
 const router: RouterType = Router();
 
-// POST /api/notifications/register - Register push token
-router.post('/register', async (req, res) => {
-  res.json({
-    message: 'POST /api/notifications/register - Not implemented yet',
-  });
+// Validation schemas
+const registerPushTokenSchema = z.object({
+  pushToken: z.string().min(1, 'Push token is required'),
 });
 
-// POST /api/cards/:id/snooze - Snooze a card
-router.post('/:id/snooze', async (req, res) => {
-  res.json({
-    message: `POST /api/cards/${req.params.id}/snooze - Not implemented yet`,
-  });
+const snoozeCardSchema = z.object({
+  duration: z
+    .number()
+    .int()
+    .min(1)
+    .max(1440)
+    .default(30)
+    .describe('Snooze duration in minutes (1-1440)'),
 });
+
+const updatePreferencesSchema = z.object({
+  notificationsEnabled: z.boolean(),
+});
+
+// POST /api/notifications/register - Register push token
+router.post(
+  '/register',
+  requireUser,
+  validate({ body: registerPushTokenSchema }),
+  asyncHandler(async (req, res) => {
+    const user = req.user!;
+    const { pushToken } = req.validated!.body as z.infer<
+      typeof registerPushTokenSchema
+    >;
+
+    // Validate the push token format
+    if (!isValidExpoPushToken(pushToken)) {
+      throw new ApiError(
+        400,
+        'INVALID_PUSH_TOKEN',
+        'Invalid Expo push token format',
+      );
+    }
+
+    // Update user's push token
+    await prisma.user.update({
+      where: { id: user.id },
+      data: { pushToken },
+    });
+
+    res.json({
+      success: true,
+      message: 'Push token registered successfully',
+    });
+  }),
+);
+
+// POST /api/notifications/cards/:id/snooze - Snooze a card's notifications
+router.post(
+  '/cards/:id/snooze',
+  requireUser,
+  validate({ body: snoozeCardSchema }),
+  asyncHandler(async (req, res) => {
+    const user = req.user!;
+    const cardId = req.params.id;
+    const { duration } = req.validated!.body as z.infer<
+      typeof snoozeCardSchema
+    >;
+
+    // Find the card and verify ownership
+    const card = await prisma.card.findUnique({
+      where: { id: cardId },
+      include: {
+        deck: {
+          select: { userId: true },
+        },
+      },
+    });
+
+    if (!card) {
+      throw new ApiError(404, 'CARD_NOT_FOUND', 'Card not found');
+    }
+
+    if (card.deck.userId !== user.id) {
+      throw new ApiError(403, 'FORBIDDEN', 'You do not own this card');
+    }
+
+    // Calculate snooze end time
+    const snoozedUntil = new Date(Date.now() + duration * 60 * 1000);
+
+    // Update the card
+    await prisma.card.update({
+      where: { id: cardId },
+      data: { snoozedUntil },
+    });
+
+    res.json({
+      success: true,
+      message: `Card snoozed for ${duration} minutes`,
+      snoozedUntil: snoozedUntil.toISOString(),
+    });
+  }),
+);
+
+// DELETE /api/notifications/cards/:id/snooze - Unsnooze a card
+router.delete(
+  '/cards/:id/snooze',
+  requireUser,
+  asyncHandler(async (req, res) => {
+    const user = req.user!;
+    const cardId = req.params.id;
+
+    // Find the card and verify ownership
+    const card = await prisma.card.findUnique({
+      where: { id: cardId },
+      include: {
+        deck: {
+          select: { userId: true },
+        },
+      },
+    });
+
+    if (!card) {
+      throw new ApiError(404, 'CARD_NOT_FOUND', 'Card not found');
+    }
+
+    if (card.deck.userId !== user.id) {
+      throw new ApiError(403, 'FORBIDDEN', 'You do not own this card');
+    }
+
+    // Clear the snooze
+    await prisma.card.update({
+      where: { id: cardId },
+      data: { snoozedUntil: null },
+    });
+
+    res.json({
+      success: true,
+      message: 'Card unsnooze successful',
+    });
+  }),
+);
 
 // PATCH /api/notifications/preferences - Update notification preferences
-router.patch('/preferences', async (req, res) => {
-  res.json({
-    message: 'PATCH /api/notifications/preferences - Not implemented yet',
-  });
-});
+router.patch(
+  '/preferences',
+  requireUser,
+  validate({ body: updatePreferencesSchema }),
+  asyncHandler(async (req, res) => {
+    const user = req.user!;
+    const { notificationsEnabled } = req.validated!.body as z.infer<
+      typeof updatePreferencesSchema
+    >;
+
+    // Update user's notification preferences
+    await prisma.user.update({
+      where: { id: user.id },
+      data: { notificationsEnabled },
+    });
+
+    res.json({
+      success: true,
+      message: `Notifications ${notificationsEnabled ? 'enabled' : 'disabled'}`,
+      notificationsEnabled,
+    });
+  }),
+);
+
+// GET /api/notifications/preferences - Get notification preferences
+router.get(
+  '/preferences',
+  requireUser,
+  asyncHandler(async (req, res) => {
+    const user = req.user!;
+
+    res.json({
+      notificationsEnabled: user.notificationsEnabled,
+      hasPushToken: !!user.pushToken,
+    });
+  }),
+);
 
 export default router;

--- a/apps/server/src/services/__tests__/card-notifications.test.ts
+++ b/apps/server/src/services/__tests__/card-notifications.test.ts
@@ -1,0 +1,148 @@
+import {
+  markCardsAsNotified,
+  markCardAsNotified,
+  clearNotificationStatus,
+  removeUserPushToken,
+} from '@/services/card-notifications';
+import { prisma } from '@/lib/prisma';
+
+// Mock Prisma
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    card: {
+      updateMany: jest.fn(),
+      update: jest.fn(),
+    },
+    user: {
+      update: jest.fn(),
+    },
+  },
+}));
+
+const mockPrisma = prisma as jest.Mocked<typeof prisma>;
+
+describe('Card Notifications Service', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('markCardsAsNotified', () => {
+    it('should mark multiple cards as notified', async () => {
+      (mockPrisma.card.updateMany as jest.Mock).mockResolvedValue({ count: 3 });
+
+      const result = await markCardsAsNotified(['card-1', 'card-2', 'card-3']);
+
+      expect(result).toBe(3);
+      expect(mockPrisma.card.updateMany).toHaveBeenCalledWith({
+        where: {
+          id: {
+            in: ['card-1', 'card-2', 'card-3'],
+          },
+        },
+        data: {
+          lastNotificationSent: expect.any(Date),
+        },
+      });
+    });
+
+    it('should return 0 for empty array', async () => {
+      const result = await markCardsAsNotified([]);
+
+      expect(result).toBe(0);
+      expect(mockPrisma.card.updateMany).not.toHaveBeenCalled();
+    });
+
+    it('should handle partial updates', async () => {
+      (mockPrisma.card.updateMany as jest.Mock).mockResolvedValue({ count: 2 });
+
+      const result = await markCardsAsNotified(['card-1', 'card-2', 'card-3']);
+
+      expect(result).toBe(2);
+    });
+  });
+
+  describe('markCardAsNotified', () => {
+    it('should mark a single card as notified', async () => {
+      (mockPrisma.card.update as jest.Mock).mockResolvedValue({
+        id: 'card-1',
+        lastNotificationSent: new Date(),
+      });
+
+      const result = await markCardAsNotified('card-1');
+
+      expect(result).toBe(true);
+      expect(mockPrisma.card.update).toHaveBeenCalledWith({
+        where: { id: 'card-1' },
+        data: {
+          lastNotificationSent: expect.any(Date),
+        },
+      });
+    });
+
+    it('should return false if card does not exist', async () => {
+      (mockPrisma.card.update as jest.Mock).mockRejectedValue(
+        new Error('Record not found'),
+      );
+
+      const result = await markCardAsNotified('non-existent-card');
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('clearNotificationStatus', () => {
+    it('should clear notification status for multiple cards', async () => {
+      (mockPrisma.card.updateMany as jest.Mock).mockResolvedValue({ count: 2 });
+
+      const result = await clearNotificationStatus(['card-1', 'card-2']);
+
+      expect(result).toBe(2);
+      expect(mockPrisma.card.updateMany).toHaveBeenCalledWith({
+        where: {
+          id: {
+            in: ['card-1', 'card-2'],
+          },
+        },
+        data: {
+          lastNotificationSent: null,
+        },
+      });
+    });
+
+    it('should return 0 for empty array', async () => {
+      const result = await clearNotificationStatus([]);
+
+      expect(result).toBe(0);
+      expect(mockPrisma.card.updateMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('removeUserPushToken', () => {
+    it('should remove push token for user', async () => {
+      (mockPrisma.user.update as jest.Mock).mockResolvedValue({
+        id: 'user-1',
+        pushToken: null,
+      });
+
+      const result = await removeUserPushToken('user-1');
+
+      expect(result).toBe(true);
+      expect(mockPrisma.user.update).toHaveBeenCalledWith({
+        where: { id: 'user-1' },
+        data: {
+          pushToken: null,
+        },
+      });
+    });
+
+    it('should return false if user does not exist', async () => {
+      (mockPrisma.user.update as jest.Mock).mockRejectedValue(
+        new Error('Record not found'),
+      );
+
+      const result = await removeUserPushToken('non-existent-user');
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/apps/server/src/services/__tests__/notification-orchestrator.test.ts
+++ b/apps/server/src/services/__tests__/notification-orchestrator.test.ts
@@ -1,0 +1,308 @@
+import { sendDueCardNotifications } from '@/services/notification-orchestrator';
+import { findDueCards } from '@/services/due-cards';
+import {
+  groupCardsByUserAndDeck,
+  prepareNotificationPayload,
+} from '@/services/notification-grouping';
+import {
+  sendBatchNotifications,
+  logNotificationResults,
+} from '@/services/push-notifications';
+import {
+  markCardsAsNotified,
+  removeUserPushToken,
+} from '@/services/card-notifications';
+
+// Mock all dependencies
+jest.mock('@/services/due-cards');
+jest.mock('@/services/notification-grouping');
+jest.mock('@/services/push-notifications');
+jest.mock('@/services/card-notifications');
+
+const mockFindDueCards = findDueCards as jest.MockedFunction<
+  typeof findDueCards
+>;
+const mockGroupCardsByUserAndDeck =
+  groupCardsByUserAndDeck as jest.MockedFunction<
+    typeof groupCardsByUserAndDeck
+  >;
+const mockPrepareNotificationPayload =
+  prepareNotificationPayload as jest.MockedFunction<
+    typeof prepareNotificationPayload
+  >;
+const mockSendBatchNotifications =
+  sendBatchNotifications as jest.MockedFunction<typeof sendBatchNotifications>;
+const mockLogNotificationResults =
+  logNotificationResults as jest.MockedFunction<typeof logNotificationResults>;
+const mockMarkCardsAsNotified = markCardsAsNotified as jest.MockedFunction<
+  typeof markCardsAsNotified
+>;
+const mockRemoveUserPushToken = removeUserPushToken as jest.MockedFunction<
+  typeof removeUserPushToken
+>;
+
+describe('Notification Orchestrator', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return early when no cards are due', async () => {
+    mockFindDueCards.mockResolvedValue([]);
+
+    const result = await sendDueCardNotifications();
+
+    expect(result.totalCardsFound).toBe(0);
+    expect(result.totalUsersNotified).toBe(0);
+    expect(mockGroupCardsByUserAndDeck).not.toHaveBeenCalled();
+    expect(mockSendBatchNotifications).not.toHaveBeenCalled();
+  });
+
+  it('should return early when no users have valid push tokens', async () => {
+    mockFindDueCards.mockResolvedValue([
+      {
+        id: 'card-1',
+        front: 'Q1',
+        nextReviewDate: new Date(),
+        lastNotificationSent: null,
+        snoozedUntil: null,
+        deck: {
+          id: 'deck-1',
+          title: 'Math',
+          userId: 'user-1',
+          parentDeckId: null,
+        },
+        user: {
+          id: 'user-1',
+          clerkId: 'clerk-1',
+          pushToken: null,
+          notificationsEnabled: true,
+        },
+      },
+    ]);
+    mockGroupCardsByUserAndDeck.mockReturnValue([]);
+
+    const result = await sendDueCardNotifications();
+
+    expect(result.totalCardsFound).toBe(1);
+    expect(result.totalUsersNotified).toBe(0);
+    expect(mockSendBatchNotifications).not.toHaveBeenCalled();
+  });
+
+  it('should orchestrate the full notification flow', async () => {
+    const mockCards = [
+      {
+        id: 'card-1',
+        front: 'Q1',
+        nextReviewDate: new Date(),
+        lastNotificationSent: null,
+        snoozedUntil: null,
+        deck: {
+          id: 'deck-1',
+          title: 'Math',
+          userId: 'user-1',
+          parentDeckId: null,
+        },
+        user: {
+          id: 'user-1',
+          clerkId: 'clerk-1',
+          pushToken: 'token-1',
+          notificationsEnabled: true,
+        },
+      },
+      {
+        id: 'card-2',
+        front: 'Q2',
+        nextReviewDate: new Date(),
+        lastNotificationSent: null,
+        snoozedUntil: null,
+        deck: {
+          id: 'deck-1',
+          title: 'Math',
+          userId: 'user-1',
+          parentDeckId: null,
+        },
+        user: {
+          id: 'user-1',
+          clerkId: 'clerk-1',
+          pushToken: 'token-1',
+          notificationsEnabled: true,
+        },
+      },
+    ];
+
+    const mockGroups = [
+      {
+        userId: 'user-1',
+        clerkId: 'clerk-1',
+        pushToken: 'token-1',
+        decks: [
+          {
+            deckId: 'deck-1',
+            deckTitle: 'Math',
+            parentDeckId: null,
+            cardCount: 2,
+            cardIds: ['card-1', 'card-2'],
+          },
+        ],
+        totalCards: 2,
+      },
+    ];
+
+    mockFindDueCards.mockResolvedValue(mockCards);
+    mockGroupCardsByUserAndDeck.mockReturnValue(mockGroups);
+    mockPrepareNotificationPayload.mockReturnValue({
+      title: 'Cards ready for review!',
+      body: '2 cards due in Math',
+      data: {
+        type: 'due_cards',
+        cardIds: ['card-1', 'card-2'],
+        deckIds: ['deck-1'],
+        totalCards: 2,
+      },
+    });
+    mockSendBatchNotifications.mockResolvedValue([
+      { pushToken: 'token-1', success: true, ticketId: 'ticket-1' },
+    ]);
+    mockMarkCardsAsNotified.mockResolvedValue(2);
+
+    const result = await sendDueCardNotifications();
+
+    expect(result.totalCardsFound).toBe(2);
+    expect(result.totalUsersNotified).toBe(1);
+    expect(result.totalNotificationsSent).toBe(1);
+    expect(result.successfulNotifications).toBe(1);
+    expect(result.failedNotifications).toBe(0);
+    expect(result.cardsMarkedAsNotified).toBe(2);
+
+    expect(mockMarkCardsAsNotified).toHaveBeenCalledWith(['card-1', 'card-2']);
+    expect(mockLogNotificationResults).toHaveBeenCalled();
+  });
+
+  it('should handle failed notifications', async () => {
+    const mockCards = [
+      {
+        id: 'card-1',
+        front: 'Q1',
+        nextReviewDate: new Date(),
+        lastNotificationSent: null,
+        snoozedUntil: null,
+        deck: {
+          id: 'deck-1',
+          title: 'Math',
+          userId: 'user-1',
+          parentDeckId: null,
+        },
+        user: {
+          id: 'user-1',
+          clerkId: 'clerk-1',
+          pushToken: 'token-1',
+          notificationsEnabled: true,
+        },
+      },
+    ];
+
+    const mockGroups = [
+      {
+        userId: 'user-1',
+        clerkId: 'clerk-1',
+        pushToken: 'token-1',
+        decks: [
+          {
+            deckId: 'deck-1',
+            deckTitle: 'Math',
+            parentDeckId: null,
+            cardCount: 1,
+            cardIds: ['card-1'],
+          },
+        ],
+        totalCards: 1,
+      },
+    ];
+
+    mockFindDueCards.mockResolvedValue(mockCards);
+    mockGroupCardsByUserAndDeck.mockReturnValue(mockGroups);
+    mockPrepareNotificationPayload.mockReturnValue({
+      title: 'Time to review!',
+      body: '1 card due in Math',
+      data: {
+        type: 'due_cards',
+        cardIds: ['card-1'],
+        deckIds: ['deck-1'],
+        totalCards: 1,
+      },
+    });
+    mockSendBatchNotifications.mockResolvedValue([
+      { pushToken: 'token-1', success: false, error: 'Network error' },
+    ]);
+
+    const result = await sendDueCardNotifications();
+
+    expect(result.successfulNotifications).toBe(0);
+    expect(result.failedNotifications).toBe(1);
+    expect(result.cardsMarkedAsNotified).toBe(0);
+    expect(mockMarkCardsAsNotified).not.toHaveBeenCalled();
+  });
+
+  it('should remove invalid push tokens', async () => {
+    const mockCards = [
+      {
+        id: 'card-1',
+        front: 'Q1',
+        nextReviewDate: new Date(),
+        lastNotificationSent: null,
+        snoozedUntil: null,
+        deck: {
+          id: 'deck-1',
+          title: 'Math',
+          userId: 'user-1',
+          parentDeckId: null,
+        },
+        user: {
+          id: 'user-1',
+          clerkId: 'clerk-1',
+          pushToken: 'token-1',
+          notificationsEnabled: true,
+        },
+      },
+    ];
+
+    const mockGroups = [
+      {
+        userId: 'user-1',
+        clerkId: 'clerk-1',
+        pushToken: 'token-1',
+        decks: [
+          {
+            deckId: 'deck-1',
+            deckTitle: 'Math',
+            parentDeckId: null,
+            cardCount: 1,
+            cardIds: ['card-1'],
+          },
+        ],
+        totalCards: 1,
+      },
+    ];
+
+    mockFindDueCards.mockResolvedValue(mockCards);
+    mockGroupCardsByUserAndDeck.mockReturnValue(mockGroups);
+    mockPrepareNotificationPayload.mockReturnValue({
+      title: 'Time to review!',
+      body: '1 card due in Math',
+      data: {
+        type: 'due_cards',
+        cardIds: ['card-1'],
+        deckIds: ['deck-1'],
+        totalCards: 1,
+      },
+    });
+    mockSendBatchNotifications.mockResolvedValue([
+      { pushToken: 'token-1', success: false, error: 'DeviceNotRegistered' },
+    ]);
+    mockRemoveUserPushToken.mockResolvedValue(true);
+
+    await sendDueCardNotifications();
+
+    expect(mockRemoveUserPushToken).toHaveBeenCalledWith('user-1');
+  });
+});

--- a/apps/server/src/services/card-notifications.ts
+++ b/apps/server/src/services/card-notifications.ts
@@ -1,0 +1,110 @@
+import { prisma } from '@/lib/prisma';
+
+/**
+ * Marks cards as notified by updating their lastNotificationSent timestamp.
+ * This function is idempotent - calling it multiple times with the same card IDs
+ * will simply update the timestamp again.
+ *
+ * @param cardIds - Array of card IDs to mark as notified
+ * @returns Number of cards updated
+ */
+export async function markCardsAsNotified(cardIds: string[]): Promise<number> {
+  if (cardIds.length === 0) {
+    return 0;
+  }
+
+  const result = await prisma.card.updateMany({
+    where: {
+      id: {
+        in: cardIds,
+      },
+    },
+    data: {
+      lastNotificationSent: new Date(),
+    },
+  });
+
+  console.log(`[CardNotifications] Marked ${result.count} cards as notified`);
+  return result.count;
+}
+
+/**
+ * Marks a single card as notified.
+ *
+ * @param cardId - The card ID to mark as notified
+ * @returns true if the card was updated, false otherwise
+ */
+export async function markCardAsNotified(cardId: string): Promise<boolean> {
+  try {
+    await prisma.card.update({
+      where: { id: cardId },
+      data: {
+        lastNotificationSent: new Date(),
+      },
+    });
+    return true;
+  } catch (error) {
+    // Card might not exist
+    console.error(
+      `[CardNotifications] Failed to mark card ${cardId} as notified:`,
+      error,
+    );
+    return false;
+  }
+}
+
+/**
+ * Clears the notification status for cards (resets lastNotificationSent to null).
+ * This is typically called when a card is reviewed, allowing it to be notified again
+ * for its next review date.
+ *
+ * @param cardIds - Array of card IDs to clear notification status
+ * @returns Number of cards updated
+ */
+export async function clearNotificationStatus(
+  cardIds: string[],
+): Promise<number> {
+  if (cardIds.length === 0) {
+    return 0;
+  }
+
+  const result = await prisma.card.updateMany({
+    where: {
+      id: {
+        in: cardIds,
+      },
+    },
+    data: {
+      lastNotificationSent: null,
+    },
+  });
+
+  return result.count;
+}
+
+/**
+ * Removes a user's push token from the database.
+ * This is called when we receive a DeviceNotRegistered error from Expo,
+ * indicating the token is no longer valid.
+ *
+ * @param userId - The user ID whose push token should be removed
+ * @returns true if the token was removed, false otherwise
+ */
+export async function removeUserPushToken(userId: string): Promise<boolean> {
+  try {
+    await prisma.user.update({
+      where: { id: userId },
+      data: {
+        pushToken: null,
+      },
+    });
+    console.log(`[CardNotifications] Removed push token for user ${userId}`);
+    return true;
+  } catch (error) {
+    console.error(
+      `[CardNotifications] Failed to remove push token for user ${userId}:`,
+      error,
+    );
+    return false;
+  }
+}

--- a/apps/server/src/services/notification-orchestrator.ts
+++ b/apps/server/src/services/notification-orchestrator.ts
@@ -1,0 +1,150 @@
+import { findDueCards } from './due-cards';
+import {
+  groupCardsByUserAndDeck,
+  prepareNotificationPayload,
+} from './notification-grouping';
+import {
+  sendBatchNotifications,
+  logNotificationResults,
+  type PushNotificationResult,
+} from './push-notifications';
+import { markCardsAsNotified, removeUserPushToken } from './card-notifications';
+
+/**
+ * Result of the notification orchestration process.
+ */
+export interface NotificationOrchestrationResult {
+  totalCardsFound: number;
+  totalUsersNotified: number;
+  totalNotificationsSent: number;
+  successfulNotifications: number;
+  failedNotifications: number;
+  cardsMarkedAsNotified: number;
+}
+
+/**
+ * Orchestrates the entire notification process:
+ * 1. Find cards due for review
+ * 2. Group cards by user and deck
+ * 3. Send push notifications
+ * 4. Mark successfully notified cards in the database
+ *
+ * @returns Result of the orchestration process
+ */
+export async function sendDueCardNotifications(): Promise<NotificationOrchestrationResult> {
+  const result: NotificationOrchestrationResult = {
+    totalCardsFound: 0,
+    totalUsersNotified: 0,
+    totalNotificationsSent: 0,
+    successfulNotifications: 0,
+    failedNotifications: 0,
+    cardsMarkedAsNotified: 0,
+  };
+
+  try {
+    // Step 1: Find cards due for review
+    const dueCards = await findDueCards();
+    result.totalCardsFound = dueCards.length;
+
+    if (dueCards.length === 0) {
+      console.log('[NotificationOrchestrator] No cards due for notification');
+      return result;
+    }
+
+    console.log(
+      `[NotificationOrchestrator] Found ${dueCards.length} cards due for notification`,
+    );
+
+    // Step 2: Group cards by user and deck
+    const userGroups = groupCardsByUserAndDeck(dueCards);
+    result.totalUsersNotified = userGroups.length;
+
+    if (userGroups.length === 0) {
+      console.log(
+        '[NotificationOrchestrator] No users with valid push tokens to notify',
+      );
+      return result;
+    }
+
+    console.log(
+      `[NotificationOrchestrator] Grouped cards for ${userGroups.length} users`,
+    );
+
+    // Step 3: Prepare and send notifications
+    const notifications = userGroups.map((group) => {
+      const payload = prepareNotificationPayload(group);
+      return {
+        pushToken: group.pushToken,
+        title: payload.title,
+        body: payload.body,
+        data: payload.data as Record<string, unknown>,
+        // Track which cards belong to this notification for marking
+        _cardIds: payload.data.cardIds,
+        _userId: group.userId,
+      };
+    });
+
+    result.totalNotificationsSent = notifications.length;
+
+    const sendResults = await sendBatchNotifications(
+      notifications.map((n) => ({
+        pushToken: n.pushToken,
+        title: n.title,
+        body: n.body,
+        data: n.data,
+      })),
+    );
+
+    // Log results
+    logNotificationResults(sendResults);
+
+    // Count successes and failures
+    result.successfulNotifications = sendResults.filter(
+      (r) => r.success,
+    ).length;
+    result.failedNotifications = sendResults.filter((r) => !r.success).length;
+
+    // Step 4: Mark cards as notified for successful sends
+    const successfulCardIds: string[] = [];
+    const tokensToRemove: { userId: string; pushToken: string }[] = [];
+
+    for (let i = 0; i < sendResults.length; i++) {
+      const sendResult = sendResults[i];
+      const notification = notifications[i];
+
+      if (sendResult.success) {
+        // Add all card IDs from this successful notification
+        successfulCardIds.push(...notification._cardIds);
+      } else if (
+        sendResult.error?.includes('DeviceNotRegistered') ||
+        sendResult.error?.includes('Invalid')
+      ) {
+        // Track tokens that need to be removed
+        tokensToRemove.push({
+          userId: notification._userId,
+          pushToken: notification.pushToken,
+        });
+      }
+    }
+
+    // Mark successfully notified cards
+    if (successfulCardIds.length > 0) {
+      result.cardsMarkedAsNotified =
+        await markCardsAsNotified(successfulCardIds);
+    }
+
+    // Remove invalid push tokens
+    for (const { userId } of tokensToRemove) {
+      await removeUserPushToken(userId);
+    }
+
+    console.log(
+      `[NotificationOrchestrator] Complete: ${result.successfulNotifications}/${result.totalNotificationsSent} notifications sent, ${result.cardsMarkedAsNotified} cards marked as notified`,
+    );
+
+    return result;
+  } catch (error) {
+    console.error('[NotificationOrchestrator] Error:', error);
+    throw error;
+  }
+}

--- a/apps/server/src/services/scheduler.ts
+++ b/apps/server/src/services/scheduler.ts
@@ -1,11 +1,12 @@
 import cron, { type ScheduledTask } from 'node-cron';
+import { sendDueCardNotifications } from './notification-orchestrator';
 
 let schedulerTask: ScheduledTask | null = null;
 let isRunning = false;
 
 /**
- * Placeholder for the notification check function.
- * Will be implemented in subsequent sub-issues (#22-#25).
+ * Runs the notification check process.
+ * Finds due cards, groups them, sends notifications, and marks them as notified.
  */
 async function runNotificationCheck(): Promise<void> {
   // Prevent concurrent runs
@@ -18,12 +19,10 @@ async function runNotificationCheck(): Promise<void> {
   console.log('[Scheduler] Running notification check...');
 
   try {
-    // TODO: Implement in #22-#25
-    // 1. Find cards due for review (±7 min window)
-    // 2. Group by user and deck
-    // 3. Send push notifications via Expo
-    // 4. Mark cards as notified
-    console.log('[Scheduler] Notification check complete');
+    const result = await sendDueCardNotifications();
+    console.log(
+      `[Scheduler] Notification check complete - ${result.totalCardsFound} cards found, ${result.successfulNotifications} notifications sent`,
+    );
   } catch (error) {
     console.error('[Scheduler] Error:', error);
   } finally {


### PR DESCRIPTION
Closes #25

**Parent Issue:** #20
**Feature Branch PR:** #69

## Summary
Implements the function to mark cards as notified in the database and wires up the complete notification system.

## Changes

### Card Notifications Service (`services/card-notifications.ts`)
- `markCardsAsNotified(cardIds)` - Batch update `lastNotificationSent` timestamp
- `markCardAsNotified(cardId)` - Single card update
- `clearNotificationStatus(cardIds)` - Reset notification status (for after review)
- `removeUserPushToken(userId)` - Remove invalid push tokens

### Notification Orchestrator (`services/notification-orchestrator.ts`)
- `sendDueCardNotifications()` - Coordinates the full notification flow:
  1. Find cards due for review
  2. Group by user and deck
  3. Send push notifications
  4. Mark successfully notified cards
  5. Remove invalid push tokens

### Scheduler Integration
- Updated scheduler to use the notification orchestrator
- Logs notification results after each run

### Notification Routes (`routes/notifications.ts`)
- `POST /register` - Register Expo push token
- `POST /cards/:id/snooze` - Snooze card notifications
- `DELETE /cards/:id/snooze` - Unsnooze card
- `PATCH /preferences` - Update notification preferences
- `GET /preferences` - Get notification preferences

### Tests
- Unit tests for card-notifications service (8 tests)
- Unit tests for notification-orchestrator (5 tests)
- Updated notification routes tests (10 tests)

## Schema Note
Uses existing `lastNotificationSent` field instead of `notified`/`notifiedAt` as mentioned in the original issue, since the schema has evolved.